### PR TITLE
Add Vue router and pages

### DIFF
--- a/web-app/package-lock.json
+++ b/web-app/package-lock.json
@@ -8,7 +8,8 @@
       "name": "web-app",
       "version": "0.0.0",
       "dependencies": {
-        "vue": "^3.5.13"
+        "vue": "^3.5.13",
+        "vue-router": "^4.3.0"
       },
       "devDependencies": {
         "@types/node": "^22.15.29",
@@ -1169,6 +1170,12 @@
         "he": "^1.2.0"
       }
     },
+    "node_modules/@vue/devtools-api": {
+      "version": "6.6.4",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-6.6.4.tgz",
+      "integrity": "sha512-sGhTPMuXqZ1rVOk32RylztWkfXTRhuS7vgAKv0zjqk8gbsHkJ7xfFf+jbySxt7tWObEJwyKaHMikV/WGDiQm8g==",
+      "license": "MIT"
+    },
     "node_modules/@vue/language-core": {
       "version": "2.2.10",
       "resolved": "https://registry.npmjs.org/@vue/language-core/-/language-core-2.2.10.tgz",
@@ -2251,6 +2258,21 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vue-router": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-4.5.1.tgz",
+      "integrity": "sha512-ogAF3P97NPm8fJsE4by9dwSYtDwXIY1nFY9T6DyQnGHd1E2Da94w9JIolpe42LJGIl0DwOHBi8TcRPlPGwbTtw==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/devtools-api": "^6.6.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/posva"
+      },
+      "peerDependencies": {
+        "vue": "^3.2.0"
       }
     },
     "node_modules/vue-tsc": {

--- a/web-app/package.json
+++ b/web-app/package.json
@@ -10,7 +10,8 @@
     "test": "vitest"
   },
   "dependencies": {
-    "vue": "^3.5.13"
+    "vue": "^3.5.13",
+    "vue-router": "^4.3.0"
   },
   "devDependencies": {
     "@types/node": "^22.15.29",

--- a/web-app/src/App.vue
+++ b/web-app/src/App.vue
@@ -1,30 +1,23 @@
 <script setup lang="ts">
-import HelloWorld from './components/HelloWorld.vue'
+import { RouterLink, RouterView } from 'vue-router';
 </script>
 
 <template>
-  <div>
-    <a href="https://vite.dev" target="_blank">
-      <img src="/vite.svg" class="logo" alt="Vite logo" />
-    </a>
-    <a href="https://vuejs.org/" target="_blank">
-      <img src="./assets/vue.svg" class="logo vue" alt="Vue logo" />
-    </a>
-  </div>
-  <HelloWorld msg="Vite + Vue" />
+  <nav>
+    <RouterLink to="/">Main</RouterLink> |
+    <RouterLink to="/search">Search</RouterLink> |
+    <RouterLink to="/news-prices">News & Prices</RouterLink> |
+    <RouterLink to="/portfolio">Portfolio</RouterLink> |
+    <RouterLink to="/pro">Pro</RouterLink>
+  </nav>
+  <RouterView />
 </template>
 
 <style scoped>
-.logo {
-  height: 6em;
-  padding: 1.5em;
-  will-change: filter;
-  transition: filter 300ms;
+nav {
+  margin-bottom: 1rem;
 }
-.logo:hover {
-  filter: drop-shadow(0 0 2em #646cffaa);
-}
-.logo.vue:hover {
-  filter: drop-shadow(0 0 2em #42b883aa);
+nav a {
+  margin: 0 0.5rem;
 }
 </style>

--- a/web-app/src/main.ts
+++ b/web-app/src/main.ts
@@ -1,5 +1,6 @@
-import { createApp } from 'vue'
-import './style.css'
-import App from './App.vue'
+import { createApp } from 'vue';
+import App from './App.vue';
+import router from './router';
+import './style.css';
 
-createApp(App).mount('#app')
+createApp(App).use(router).mount('#app');

--- a/web-app/src/pages/DetailPage.vue
+++ b/web-app/src/pages/DetailPage.vue
@@ -1,0 +1,11 @@
+<script setup lang="ts">
+import { useRoute } from 'vue-router';
+const route = useRoute();
+</script>
+
+<template>
+  <div class="page">
+    <h1>Detail Page</h1>
+    <p>Symbol: {{ route.params.symbol }}</p>
+  </div>
+</template>

--- a/web-app/src/pages/MainPage.vue
+++ b/web-app/src/pages/MainPage.vue
@@ -1,0 +1,8 @@
+<template>
+  <div class="page">
+    <h1>Main Page</h1>
+  </div>
+</template>
+
+<script setup lang="ts">
+</script>

--- a/web-app/src/pages/NewsPricesPage.vue
+++ b/web-app/src/pages/NewsPricesPage.vue
@@ -1,0 +1,8 @@
+<template>
+  <div class="page">
+    <h1>News & Prices</h1>
+  </div>
+</template>
+
+<script setup lang="ts">
+</script>

--- a/web-app/src/pages/PortfolioPage.vue
+++ b/web-app/src/pages/PortfolioPage.vue
@@ -1,0 +1,8 @@
+<template>
+  <div class="page">
+    <h1>Portfolio Page</h1>
+  </div>
+</template>
+
+<script setup lang="ts">
+</script>

--- a/web-app/src/pages/ProPage.vue
+++ b/web-app/src/pages/ProPage.vue
@@ -1,0 +1,8 @@
+<template>
+  <div class="page">
+    <h1>Pro Page</h1>
+  </div>
+</template>
+
+<script setup lang="ts">
+</script>

--- a/web-app/src/pages/SearchPage.vue
+++ b/web-app/src/pages/SearchPage.vue
@@ -1,0 +1,8 @@
+<template>
+  <div class="page">
+    <h1>Search Page</h1>
+  </div>
+</template>
+
+<script setup lang="ts">
+</script>

--- a/web-app/src/router.ts
+++ b/web-app/src/router.ts
@@ -1,0 +1,23 @@
+import { createRouter, createWebHistory } from 'vue-router';
+import MainPage from '@/pages/MainPage.vue';
+import SearchPage from '@/pages/SearchPage.vue';
+import DetailPage from '@/pages/DetailPage.vue';
+import NewsPricesPage from '@/pages/NewsPricesPage.vue';
+import PortfolioPage from '@/pages/PortfolioPage.vue';
+import ProPage from '@/pages/ProPage.vue';
+
+const routes = [
+  { path: '/', name: 'main', component: MainPage },
+  { path: '/search', name: 'search', component: SearchPage },
+  { path: '/detail/:symbol?', name: 'detail', component: DetailPage },
+  { path: '/news-prices', name: 'news-prices', component: NewsPricesPage },
+  { path: '/portfolio', name: 'portfolio', component: PortfolioPage },
+  { path: '/pro', name: 'pro', component: ProPage }
+];
+
+const router = createRouter({
+  history: createWebHistory(),
+  routes
+});
+
+export default router;

--- a/web-app/tests/router.test.ts
+++ b/web-app/tests/router.test.ts
@@ -1,0 +1,14 @@
+import router from '../src/router';
+import { describe, it, expect } from 'vitest';
+
+describe('router', () => {
+  it('resolves search route', () => {
+    const match = router.resolve('/search');
+    expect(match.name).toBe('search');
+  });
+
+  it('returns undefined for unknown route', () => {
+    const match = router.resolve('/no-route');
+    expect(match.name).toBeUndefined();
+  });
+});

--- a/web-app/vite.config.ts
+++ b/web-app/vite.config.ts
@@ -6,10 +6,12 @@ export default defineConfig({
   plugins: [vue()],
   resolve: {
     alias: {
-      '@': path.resolve(__dirname, 'src')
+      '@': path.resolve(__dirname, 'src'),
+      '@pages': path.resolve(__dirname, 'src/pages')
     }
   },
   test: {
-    environment: 'jsdom'
+    environment: 'jsdom',
+    globals: true
   }
 });


### PR DESCRIPTION
## Summary
- add vue-router setup
- create Main, Search, Detail, NewsPrices, Portfolio and Pro page components
- update entrypoint and App layout to use router
- expose page alias and globals for tests in vite config
- test router resolves routes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68401043171c832594751bf629929667