### PR TITLE
Add basic CI with Lighthouse

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: web-app
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: web-app/package-lock.json
+      - name: Install deps
+        run: npm ci
+      - name: Run unit tests
+        run: npm test --if-present
+      - name: Build app
+        run: npm run build --if-present
+      - name: Lighthouse audit
+        run: npx @lhci/cli autorun
+      - name: Upload Lighthouse artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: lighthouse-report
+          path: web-app/.lighthouseci

--- a/web-app/lighthouserc.json
+++ b/web-app/lighthouserc.json
@@ -1,0 +1,19 @@
+{
+  "ci": {
+    "collect": {
+      "staticDistDir": "dist"
+    },
+    "assert": {
+      "preset": "lighthouse:recommended",
+      "assertions": {
+        "categories:performance": ["error", {"minScore": 0.9}],
+        "categories:accessibility": ["error", {"minScore": 0.9}],
+        "categories:best-practices": ["error", {"minScore": 0.9}],
+        "categories:seo": ["error", {"minScore": 0.9}]
+      }
+    },
+    "upload": {
+      "target": "temporary-public-storage"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- run npm ci, tests, build, Lighthouse and export artifacts
- add default Lighthouse config with thresholds

## Testing
- `npx vitest run`
- `npx --yes @lhci/cli@0.14.0 autorun --config=./lighthouserc.json` *(fails: Chrome installation not found)*

------
https://chatgpt.com/codex/tasks/task_e_68401038a02c8325ba2268900574c5b2