### PR TITLE
Add more service tests

### DIFF
--- a/web-app/tests/MarketstackService.test.ts
+++ b/web-app/tests/MarketstackService.test.ts
@@ -68,4 +68,24 @@ describe('MarketstackService', () => {
     expect(fetchMock).toHaveBeenCalledTimes(2);
     expect(ledger.increment).toHaveBeenCalledTimes(1);
   });
+
+  it('stores quotes separately per symbol', async () => {
+    const service = new MarketstackService('k');
+    const ledger = { isSafe: vi.fn().mockReturnValue(true), increment: vi.fn() };
+    (service as any).ledger = ledger;
+    const quoteB: Quote = { ...sampleQuote, symbol: 'IBM' };
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ data: [sampleQuote] }) })
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ data: [quoteB] }) });
+    global.fetch = fetchMock as any;
+
+    const first = await service.getQuote('AAPL');
+    expect(first).toEqual(sampleQuote);
+    const second = await service.getQuote('IBM');
+    expect(second).toEqual(quoteB);
+    await service.getQuote('AAPL');
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(ledger.increment).toHaveBeenCalledTimes(2);
+  });
 });

--- a/web-app/tests/NewsService.test.ts
+++ b/web-app/tests/NewsService.test.ts
@@ -73,4 +73,23 @@ describe('NewsService', () => {
     expect(fetchMock).toHaveBeenCalledTimes(2);
     expect(ledger.increment).toHaveBeenCalledTimes(1);
   });
+
+  it('maintains separate cache entries per symbol', async () => {
+    const service = new NewsService('key');
+    const ledger = { isSafe: vi.fn().mockReturnValue(true), increment: vi.fn() };
+    (service as any).ledger = ledger;
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: true, json: async () => apiPayload() })
+      .mockResolvedValueOnce({ ok: true, json: async () => apiPayload() });
+    global.fetch = fetchMock as any;
+
+    const first = await service.getNews('AA');
+    expect(first).toEqual(sampleArticles);
+    const second = await service.getNews('BB');
+    expect(second).toEqual(sampleArticles);
+    await service.getNews('AA');
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(ledger.increment).toHaveBeenCalledTimes(2);
+  });
 });

--- a/web-app/tests/router.test.ts
+++ b/web-app/tests/router.test.ts
@@ -11,4 +11,10 @@ describe('router', () => {
     const match = router.resolve('/no-route');
     expect(match.name).toBeUndefined();
   });
+
+  it('parses optional symbol param', () => {
+    const match = router.resolve('/detail/ABC');
+    expect(match.name).toBe('detail');
+    expect(match.params.symbol).toBe('ABC');
+  });
 });


### PR DESCRIPTION
## Summary
- add coverage for per-key caching behavior in service tests
- verify dynamic segment on router

## Testing
- `npm test --silent`
- `dart format -o none --set-exit-if-changed .`
- `flutter analyze`
- `npx eslint --fix web-app/src/**/*.ts web-app/tests/**/*.ts`
- `flutter test`


------
https://chatgpt.com/codex/tasks/task_e_68401d5896488325923c0d59ec0d66ff