### PR TITLE
Improve meta info and link contrast

### DIFF
--- a/web-app/index.html
+++ b/web-app/index.html
@@ -4,6 +4,8 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="description" content="Responsive stock market dashboard built with Vue and TypeScript." />
+    <link rel="preload" href="/src/style.css" as="style" onload="this.rel='stylesheet'" />
     <title>Vite + Vue + TS</title>
   </head>
   <body>

--- a/web-app/src/style.css
+++ b/web-app/src/style.css
@@ -15,11 +15,11 @@
 
 a {
   font-weight: 500;
-  color: #646cff;
+  color: #4098ff;
   text-decoration: inherit;
 }
 a:hover {
-  color: #535bf2;
+  color: #94b0ff;
 }
 
 body {
@@ -70,8 +70,11 @@ button:focus-visible {
     color: #213547;
     background-color: #ffffff;
   }
+  a {
+    color: #00356b;
+  }
   a:hover {
-    color: #747bff;
+    color: #004c8b;
   }
   button {
     background-color: #f9f9f9;


### PR DESCRIPTION
## Summary
- add a meta description
- preload the main stylesheet
- use distinct link colors for dark and light backgrounds that satisfy WCAG AA

## Testing
- `npm test --silent` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68401d51cd208325bb2c01949c96d262