### PR TITLE
Fix LruCache eviction type error

### DIFF
--- a/web-app/src/utils/LruCache.ts
+++ b/web-app/src/utils/LruCache.ts
@@ -47,8 +47,10 @@ export class LruCache<K, V> {
    */
   put(key: K, value: V, ttlMs: number) {
     if (this.map.size >= this.capacity) {
-      const oldest = this.map.keys().next().value;
-      this.delete(oldest);
+      const first = this.map.keys().next();
+      if (!first.done) {
+        this.delete(first.value);
+      }
     }
     this.map.set(key, value);
     this.expiry.set(key, Date.now() + ttlMs);

--- a/web-app/tests/LruCache.test.ts
+++ b/web-app/tests/LruCache.test.ts
@@ -15,4 +15,12 @@ describe('LruCache', () => {
     await new Promise(r => setTimeout(r, 5));
     expect(cache.get('a')).toBeUndefined();
   });
+
+  it('evicts least recently used when capacity exceeded', () => {
+    const cache = new LruCache<string, number>(1);
+    cache.put('a', 1, 1000);
+    cache.put('b', 2, 1000);
+    expect(cache.get('a')).toBeUndefined();
+    expect(cache.get('b')).toBe(2);
+  });
 });


### PR DESCRIPTION
## Summary
- guard LruCache eviction check with iterator `.done`
- add regression test for capacity-based eviction

## Testing
- `CI=1 npm test --prefix web-app`
- `npm run build --prefix web-app`


------
https://chatgpt.com/codex/tasks/task_e_684022eeccdc8325a9834b16f5e2c76d