### PR TITLE
Unify env var names

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,8 +28,8 @@ This repository hosts a cross-platform stock market app with a Flutter mobile fr
 
 Create identical `.env` files in `mobile-app/` and `web-app/` containing:
 ```
-MARKETSTACK_KEY=YOUR_MARKETSTACK_KEY
-NEWSDATA_KEY=YOUR_NEWSDATA_KEY
+VITE_MARKETSTACK_KEY=YOUR_MARKETSTACK_KEY
+VITE_NEWSDATA_KEY=YOUR_NEWSDATA_KEY
 LHCI_GITHUB_APP_TOKEN=YOUR_LHCI_TOKEN  # CI only
 ```
 

--- a/CODING_RULES.md
+++ b/CODING_RULES.md
@@ -20,7 +20,7 @@
 15. Use Riverpod (Flutter) & Pinia (Vue) for state – avoid global mutable singletons.
 
 ## Environment & config
-16. Runtime config ONLY via env-vars / secrets manager – `MARKETSTACK_KEY`, `NEWSDATA_KEY`, etc.
+16. Runtime config ONLY via env-vars / secrets manager – `VITE_MARKETSTACK_KEY`, `VITE_NEWSDATA_KEY`, etc.
 17. Lint-defined code style: 2-space indent, single quotes, trailing newline.
 
 *(CI enforces CVE scans, licence checks, coverage threshold, and prettier formatting – see `.github/workflows/`.)*

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@
 
 ---
 ## ==== External API tokens (never commit real values) ====
-MARKETSTACK_KEY=YOUR_MARKETSTACK_KEY
-NEWSDATA_KEY=YOUR_NEWSDATA_KEY
+VITE_MARKETSTACK_KEY=YOUR_MARKETSTACK_KEY
+VITE_NEWSDATA_KEY=YOUR_NEWSDATA_KEY
 LHCI_GITHUB_APP_TOKEN=YOUR_LHCI_TOKEN  # CI only
 
 ## ✨ Features (MVP = 6 mobile screens · 6 web pages)
@@ -60,8 +60,8 @@ cd ../web-app
 npm install && npm run dev            # ⇒ http://localhost:5173
 Required env vars (MVP)
 Variable	Example	Purpose
-MARKETSTACK_KEY	9b3e…	EoD quotes
-NEWSDATA_KEY	pub_123…	News digest
+VITE_MARKETSTACK_KEY	9b3e…	EoD quotes
+VITE_NEWSDATA_KEY	pub_123…	News digest
 LHCI_GITHUB_APP_TOKEN gh_abc…   Lighthouse CI (CI only)
 
 Create identical .env files in mobile-app/ and web-app/.


### PR DESCRIPTION
## Summary
- update AGENTS guidelines with VITE_ prefixed vars
- document VITE_ vars in README
- note same scheme in CODING_RULES

## Testing
- `npm test`
- `npx eslint . --fix` *(fails: ESLint couldn't find a config)*
- `dart format -o none .` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684025e42d3c832592fe92f91e4b86a5