### PR TITLE
Add Flutter widget tests

### DIFF
--- a/mobile-app/test/auth_screen_test.dart
+++ b/mobile-app/test/auth_screen_test.dart
@@ -1,0 +1,17 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobile_app/screens/auth/auth_screen.dart';
+
+void main() {
+  group('AuthScreen', () {
+    testWidgets('shows expected text', (tester) async {
+      await tester.pumpWidget(const MaterialApp(home: AuthScreen()));
+      expect(find.text('Auth Screen'), findsOneWidget);
+    });
+
+    testWidgets('does not show wrong text', (tester) async {
+      await tester.pumpWidget(const MaterialApp(home: AuthScreen()));
+      expect(find.text('Wrong'), findsNothing);
+    });
+  });
+}

--- a/mobile-app/test/detail_screen_test.dart
+++ b/mobile-app/test/detail_screen_test.dart
@@ -1,0 +1,17 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobile_app/screens/detail/detail_screen.dart';
+
+void main() {
+  group('DetailScreen', () {
+    testWidgets('shows expected text', (tester) async {
+      await tester.pumpWidget(const MaterialApp(home: DetailScreen()));
+      expect(find.text('Detail Screen'), findsOneWidget);
+    });
+
+    testWidgets('does not show wrong text', (tester) async {
+      await tester.pumpWidget(const MaterialApp(home: DetailScreen()));
+      expect(find.text('Wrong'), findsNothing);
+    });
+  });
+}

--- a/mobile-app/test/main_screen_test.dart
+++ b/mobile-app/test/main_screen_test.dart
@@ -1,0 +1,17 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobile_app/screens/main/main_screen.dart';
+
+void main() {
+  group('MainScreen', () {
+    testWidgets('shows expected text', (tester) async {
+      await tester.pumpWidget(const MaterialApp(home: MainScreen()));
+      expect(find.text('Main Screen'), findsOneWidget);
+    });
+
+    testWidgets('does not show wrong text', (tester) async {
+      await tester.pumpWidget(const MaterialApp(home: MainScreen()));
+      expect(find.text('Wrong'), findsNothing);
+    });
+  });
+}

--- a/mobile-app/test/news_screen_test.dart
+++ b/mobile-app/test/news_screen_test.dart
@@ -1,0 +1,17 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobile_app/screens/news/news_screen.dart';
+
+void main() {
+  group('NewsScreen', () {
+    testWidgets('shows expected text', (tester) async {
+      await tester.pumpWidget(const MaterialApp(home: NewsScreen()));
+      expect(find.text('News Screen'), findsOneWidget);
+    });
+
+    testWidgets('does not show wrong text', (tester) async {
+      await tester.pumpWidget(const MaterialApp(home: NewsScreen()));
+      expect(find.text('Wrong'), findsNothing);
+    });
+  });
+}

--- a/mobile-app/test/portfolio_screen_test.dart
+++ b/mobile-app/test/portfolio_screen_test.dart
@@ -1,0 +1,17 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobile_app/screens/portfolio/portfolio_screen.dart';
+
+void main() {
+  group('PortfolioScreen', () {
+    testWidgets('shows expected text', (tester) async {
+      await tester.pumpWidget(const MaterialApp(home: PortfolioScreen()));
+      expect(find.text('Portfolio Screen'), findsOneWidget);
+    });
+
+    testWidgets('does not show wrong text', (tester) async {
+      await tester.pumpWidget(const MaterialApp(home: PortfolioScreen()));
+      expect(find.text('Wrong'), findsNothing);
+    });
+  });
+}

--- a/mobile-app/test/pro_screen_test.dart
+++ b/mobile-app/test/pro_screen_test.dart
@@ -1,0 +1,17 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobile_app/screens/pro/pro_screen.dart';
+
+void main() {
+  group('ProScreen', () {
+    testWidgets('shows expected text', (tester) async {
+      await tester.pumpWidget(const MaterialApp(home: ProScreen()));
+      expect(find.text('Pro Screen'), findsOneWidget);
+    });
+
+    testWidgets('does not show wrong text', (tester) async {
+      await tester.pumpWidget(const MaterialApp(home: ProScreen()));
+      expect(find.text('Wrong'), findsNothing);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- create `test` directory in mobile app
- add positive and negative widget tests for every screen

## Testing
- `flutter test --coverage` *(fails: `flutter` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68402f23e80c8325a13768257bcac010