### PR TITLE
Add image license attribution

### DIFF
--- a/docs/ATTRIBUTION.md
+++ b/docs/ATTRIBUTION.md
@@ -1,0 +1,10 @@
+# Icon and Image Attribution
+
+This project uses the following third-party graphics. Each icon is distributed under the MIT License.
+
+| Asset | Description | Source URL |
+|-------|-------------|------------|
+| `web-app/public/vite.svg` | Vite logo | <https://github.com/vitejs/vite/blob/main/LICENSE> |
+| `web-app/src/assets/vue.svg` | Vue.js logo | <https://github.com/vuejs/vue/blob/main/LICENSE> |
+
+


### PR DESCRIPTION
## Summary
- document third-party icon licences used by the app

## Testing
- `dart format -o none -l 80 .`
- `flutter analyze`
- `flutter test`
- `npm test` in `web-app`
- `npm exec eslint --fix "./src/**/*.{js,ts,vue}"` in `web-app`


------
https://chatgpt.com/codex/tasks/task_e_68402f159f3083259e067c6b246fdde2