### PR TITLE
Update CI for Flutter tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,17 @@ jobs:
       - name: Run tests
         run: npm test
         working-directory: web-app
+      - name: Setup Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: '3.22.x'
+          channel: stable
+      - name: Install Flutter dependencies
+        run: flutter pub get
+        working-directory: mobile-app
+      - name: Run Flutter tests
+        run: flutter test
+        working-directory: mobile-app
       - name: Build
         run: npm run build
         working-directory: web-app


### PR DESCRIPTION
## Summary
- set up Flutter 3.22 in CI using `subosito/flutter-action`
- run `flutter pub get` and `flutter test` after Node tests
- keep web build, Netlify trigger and Lighthouse steps

## Testing
- `npm test` *(passed)*
- `flutter analyze` *(failed: undefined classes in generated code)*
- `flutter test` *(failed: Test directory "test" not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840308f396483258f382995fab600d3