### PR TITLE
Add OpenAPI generation scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,8 @@ cd Stock-App1
 
 # 2 · Generate REST clients
 cd packages
-npx @openapitools/openapi-generator-cli generate -i openapi.yaml -g typescript-fetch -o generated-ts
-npx @openapitools/openapi-generator-cli generate -i openapi.yaml -g dart-dio -o generated-dart
+npm run gen:ts   # TypeScript client
+npm run gen:dart # Dart client
 cd ..
 
 # 3 · Mobile (Flutter)
@@ -86,6 +86,7 @@ Task	Mobile	Web
 Dev hot-reload	flutter run	npm run dev
 Unit tests	flutter test	npm test
 Lint / format	dart format .	npm run lint
+REST clients    –               npm run gen:ts && npm run gen:dart (in packages/)
 Build (CI)	GitHub Action → Netlify preview	(same)
 `npm run lint` in `web-app/` runs ESLint with auto-fix enabled for all TypeScript and Vue files. The linter is configured via `eslint.config.js`, enforcing 2-space indentation and single quotes.
 

--- a/packages/README.md
+++ b/packages/README.md
@@ -1,10 +1,12 @@
 # Packages
 
 This folder contains shared API contracts and generated clients for both
-the web and mobile apps. `openapi.yaml` defines a minimal spec that is used
-to generate TypeScript and Dart client stubs.
+web and mobile apps. `openapi.yaml` defines a minimal spec used to produce
+TypeScript and Dart client stubs.
 
-```
-npx @openapitools/openapi-generator-cli generate -i openapi.yaml -g typescript-fetch -o generated-ts
-npx @openapitools/openapi-generator-cli generate -i openapi.yaml -g dart-dio -o generated-dart
+Run the following scripts from this directory:
+
+```bash
+npm run gen:ts   # generates generated-ts/
+npm run gen:dart # generates generated-dart/
 ```

--- a/packages/package.json
+++ b/packages/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "packages",
+  "private": true,
+  "version": "1.0.0",
+  "type": "module",
+  "scripts": {
+    "gen:ts": "npx @openapitools/openapi-generator-cli generate -i openapi.yaml -g typescript-fetch -o generated-ts",
+    "gen:dart": "npx @openapitools/openapi-generator-cli generate -i openapi.yaml -g dart-dio -o generated-dart"
+  }
+}


### PR DESCRIPTION
## Summary
- add `gen:ts` and `gen:dart` npm scripts in `packages`
- document REST client generation in the main README and packages README

## Testing
- `npm test` within `web-app`
- `npm run lint` within `web-app` *(fails: no-unused-vars)*
- `dart format` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68403eed39ac83258dcdb44388f13cce