### PR TITLE
Clean up generated Dart tests

### DIFF
--- a/packages/generated-dart/test/default_api_test.dart
+++ b/packages/generated-dart/test/default_api_test.dart
@@ -1,25 +1,12 @@
 import 'package:test/test.dart';
 import 'package:openapi/openapi.dart';
 
-
-/// tests for DefaultApi
+/// Minimal sanity checks for the generated API client
 void main() {
-  final instance = Openapi().getDefaultApi();
-
-  group(DefaultApi, () {
-    // Get news
-    //
-    //Future<BuiltList<NewsArticle>> newsGet(String symbol) async
-    test('test newsGet', () async {
-      // TODO
+  group('DefaultApi', () {
+    test('can be constructed', () {
+      final api = Openapi().getDefaultApi();
+      expect(api, isA<DefaultApi>());
     });
-
-    // Get quote
-    //
-    //Future<Quote> quoteGet(String symbol) async
-    test('test quoteGet', () async {
-      // TODO
-    });
-
   });
 }

--- a/packages/generated-dart/test/news_article_test.dart
+++ b/packages/generated-dart/test/news_article_test.dart
@@ -1,21 +1,15 @@
 import 'package:test/test.dart';
 import 'package:openapi/openapi.dart';
 
-// tests for NewsArticle
+/// Basic checks for the generated NewsArticle model
 void main() {
-  final instance = NewsArticleBuilder();
-  // TODO add properties to the builder and call build()
-
-  group(NewsArticle, () {
-    // String title
-    test('to test the property `title`', () async {
-      // TODO
+  group('NewsArticle', () {
+    test('can be built', () {
+      final article = NewsArticle((b) => b
+        ..title = 'Foo'
+        ..url = 'http://example.com');
+      expect(article.title, 'Foo');
+      expect(article.url, 'http://example.com');
     });
-
-    // String url
-    test('to test the property `url`', () async {
-      // TODO
-    });
-
   });
 }

--- a/packages/generated-dart/test/quote_test.dart
+++ b/packages/generated-dart/test/quote_test.dart
@@ -1,21 +1,15 @@
 import 'package:test/test.dart';
 import 'package:openapi/openapi.dart';
 
-// tests for Quote
+/// Basic checks for the generated Quote model
 void main() {
-  final instance = QuoteBuilder();
-  // TODO add properties to the builder and call build()
-
-  group(Quote, () {
-    // String symbol
-    test('to test the property `symbol`', () async {
-      // TODO
+  group('Quote', () {
+    test('can be built', () {
+      final quote = Quote((b) => b
+        ..symbol = 'FOO'
+        ..price = 1.23);
+      expect(quote.symbol, 'FOO');
+      expect(quote.price, closeTo(1.23, 0.001));
     });
-
-    // double price
-    test('to test the property `price`', () async {
-      // TODO
-    });
-
   });
 }


### PR DESCRIPTION
## Summary
- replace TODOs in generated API client tests with simple construction checks

## Testing
- `dart format -o none --set-exit-if-changed .` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*
- `npm run lint --if-present` *(fails to fix 4 no-unused-vars errors)*
- `npm test --silent` *(passes, then cancelled)*

------
https://chatgpt.com/codex/tasks/task_e_68403f6d3b708325824ec3b38ef0f28c