### PR TITLE
Add debug timing logs for API calls and component loads

### DIFF
--- a/web-app/eslint.config.js
+++ b/web-app/eslint.config.js
@@ -18,7 +18,10 @@ export default [
       globals: {
         fetch: 'readonly',
         global: 'readonly',
-        setTimeout: 'readonly'
+        setTimeout: 'readonly',
+        console: 'readonly',
+        performance: 'readonly',
+        process: 'readonly'
       }
     },
     plugins: {

--- a/web-app/src/components/HeadlineCard.vue
+++ b/web-app/src/components/HeadlineCard.vue
@@ -9,9 +9,11 @@
 <script setup lang="ts">
 import { ref, onMounted } from 'vue';
 import { MarketstackService } from '@/services/MarketstackService';
+import { useLoadTimeLogger } from '@/utils/useLoadTimeLogger';
 
 const service = new MarketstackService(import.meta.env.VITE_MARKETSTACK_KEY);
 const quote = ref();
+useLoadTimeLogger('HeadlineCard');
 
 onMounted(async () => {
   quote.value = await service.getQuote('AAPL');

--- a/web-app/src/pages/DetailPage.vue
+++ b/web-app/src/pages/DetailPage.vue
@@ -1,6 +1,8 @@
 <script setup lang="ts">
 import { useRoute } from 'vue-router';
+import { useLoadTimeLogger } from '@/utils/useLoadTimeLogger';
 const route = useRoute();
+useLoadTimeLogger('DetailPage');
 </script>
 
 <template>

--- a/web-app/src/pages/MainPage.vue
+++ b/web-app/src/pages/MainPage.vue
@@ -5,4 +5,7 @@
 </template>
 
 <script setup lang="ts">
+import { useLoadTimeLogger } from '@/utils/useLoadTimeLogger';
+
+useLoadTimeLogger('MainPage');
 </script>

--- a/web-app/src/pages/NewsPricesPage.vue
+++ b/web-app/src/pages/NewsPricesPage.vue
@@ -5,4 +5,7 @@
 </template>
 
 <script setup lang="ts">
+import { useLoadTimeLogger } from '@/utils/useLoadTimeLogger';
+
+useLoadTimeLogger('NewsPricesPage');
 </script>

--- a/web-app/src/pages/PortfolioPage.vue
+++ b/web-app/src/pages/PortfolioPage.vue
@@ -5,4 +5,7 @@
 </template>
 
 <script setup lang="ts">
+import { useLoadTimeLogger } from '@/utils/useLoadTimeLogger';
+
+useLoadTimeLogger('PortfolioPage');
 </script>

--- a/web-app/src/pages/ProPage.vue
+++ b/web-app/src/pages/ProPage.vue
@@ -5,4 +5,7 @@
 </template>
 
 <script setup lang="ts">
+import { useLoadTimeLogger } from '@/utils/useLoadTimeLogger';
+
+useLoadTimeLogger('ProPage');
 </script>

--- a/web-app/src/pages/SearchPage.vue
+++ b/web-app/src/pages/SearchPage.vue
@@ -5,4 +5,7 @@
 </template>
 
 <script setup lang="ts">
+import { useLoadTimeLogger } from '@/utils/useLoadTimeLogger';
+
+useLoadTimeLogger('SearchPage');
 </script>

--- a/web-app/src/services/FxService.ts
+++ b/web-app/src/services/FxService.ts
@@ -1,5 +1,6 @@
 import { LruCache } from '@/utils/LruCache';
 import { ApiQuotaLedger } from '@/utils/ApiQuotaLedger';
+import { logApiCall } from '@/utils/logMetrics';
 
 const CACHE_TTL = 24 * 60 * 60 * 1000;
 
@@ -26,6 +27,7 @@ export class FxService {
     if (cached !== undefined) return cached;
     if (!this.ledger.isSafe()) return null;
     const url = `https://api.exchangerate.host/latest?base=${base}&symbols=${quote}`;
+    const start = performance.now();
     try {
       const resp = await fetch(url);
       if (!resp.ok) return null;
@@ -36,6 +38,8 @@ export class FxService {
       return rate;
     } catch {
       return null;
+    } finally {
+      logApiCall('FxService.getRate', start);
     }
   }
 }

--- a/web-app/src/utils/ApiQuotaLedger.ts
+++ b/web-app/src/utils/ApiQuotaLedger.ts
@@ -8,10 +8,12 @@
 export class ApiQuotaLedger {
   private rollingCount = 0;
   private windowStart = Date.now();
-  constructor(
-    private limit: number,
-    private windowMs = 24 * 60 * 60 * 1000,
-  ) {}
+  private limit: number;
+  private windowMs: number;
+  constructor(limit: number, windowMs = 24 * 60 * 60 * 1000) {
+    this.limit = limit;
+    this.windowMs = windowMs;
+  }
 
   /**
    * Increase the count for the current window.

--- a/web-app/src/utils/logMetrics.ts
+++ b/web-app/src/utils/logMetrics.ts
@@ -1,0 +1,37 @@
+/**
+ * Utilities for debug performance logging.
+ */
+export function isDev(): boolean {
+  if (typeof process !== 'undefined' && process.env.NODE_ENV !== undefined) {
+    return process.env.NODE_ENV !== 'production';
+  }
+  try {
+    return Boolean((import.meta as any).env?.DEV);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Log page or component load time when in development.
+ *
+ * @param name - Identifier for the load source.
+ * @param start - Timestamp recorded before load began.
+ */
+export function logLoadTime(name: string, start: number): void {
+  if (!isDev()) return;
+  const loadTimeMs = Math.round(performance.now() - start);
+  console.log(`[load] ${name}`, { loadTimeMs });
+}
+
+/**
+ * Log API call duration when in development.
+ *
+ * @param name - Identifier for the API call.
+ * @param start - Timestamp before the request was sent.
+ */
+export function logApiCall(name: string, start: number): void {
+  if (!isDev()) return;
+  const apiCallMs = Math.round(performance.now() - start);
+  console.log(`[api] ${name}`, { apiCallMs });
+}

--- a/web-app/src/utils/useLoadTimeLogger.ts
+++ b/web-app/src/utils/useLoadTimeLogger.ts
@@ -1,0 +1,14 @@
+import { onMounted } from 'vue';
+import { logLoadTime } from './logMetrics';
+
+/**
+ * Track component load duration in development mode.
+ *
+ * @param name - Identifier for logging.
+ */
+export function useLoadTimeLogger(name: string) {
+  const start = performance.now();
+  onMounted(() => {
+    logLoadTime(name, start);
+  });
+}

--- a/web-app/tests/logMetrics.test.ts
+++ b/web-app/tests/logMetrics.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect, vi } from 'vitest';
+import { logLoadTime, logApiCall } from '../src/utils/logMetrics';
+
+describe('logMetrics', () => {
+  it('logs when not production', () => {
+    vi.stubEnv('NODE_ENV', 'development');
+    const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    logLoadTime('p', performance.now());
+    logApiCall('a', performance.now());
+    expect(spy).toHaveBeenCalledTimes(2);
+    vi.unstubAllEnvs();
+    spy.mockRestore();
+  });
+
+  it('skips logging in production', () => {
+    vi.stubEnv('NODE_ENV', 'production');
+    const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    logLoadTime('p', performance.now());
+    logApiCall('a', performance.now());
+    expect(spy).not.toHaveBeenCalled();
+    vi.unstubAllEnvs();
+    spy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
- record API request durations in services
- log load times for pages/components in dev mode
- expose log helpers with unit tests
- configure ESLint globals

## Testing
- `npm run lint`
- `npx vitest run`
- `dart --version` *(fails: command not found)*
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68403f59a4f883259227fa3e08b6a79e