### PR TITLE
Add OpenAPI generation scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,8 @@ cd Stock-App1
 
 # 2 · Generate REST clients
 cd packages
-npx @openapitools/openapi-generator-cli generate -i openapi.yaml -g typescript-fetch -o generated-ts
-npx @openapitools/openapi-generator-cli generate -i openapi.yaml -g dart-dio -o generated-dart
+npm run gen:ts
+npm run gen:dart
 cd ..
 
 # 3 · Mobile (Flutter)

--- a/packages/README.md
+++ b/packages/README.md
@@ -5,6 +5,6 @@ the web and mobile apps. `openapi.yaml` defines a minimal spec that is used
 to generate TypeScript and Dart client stubs.
 
 ```
-npx @openapitools/openapi-generator-cli generate -i openapi.yaml -g typescript-fetch -o generated-ts
-npx @openapitools/openapi-generator-cli generate -i openapi.yaml -g dart-dio -o generated-dart
+npm run gen:ts
+npm run gen:dart
 ```

--- a/packages/package.json
+++ b/packages/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "stock-app-packages",
+  "private": true,
+  "scripts": {
+    "gen:ts": "npx @openapitools/openapi-generator-cli generate -i openapi.yaml -g typescript-fetch -o generated-ts",
+    "gen:dart": "npx @openapitools/openapi-generator-cli generate -i openapi.yaml -g dart-dio -o generated-dart"
+  }
+}


### PR DESCRIPTION
## Summary
- create `packages/package.json` with `gen:ts` and `gen:dart` scripts
- document the new commands in `README.md` and `packages/README.md`

## Testing
- `npm run lint` *(fails: no-unused-vars)*
- `npm test` *(fails: hangs in watch mode)*

------
https://chatgpt.com/codex/tasks/task_e_68403ee057048325a09e2e3e68e91db4