### PR TITLE
Add component and page tests

### DIFF
--- a/web-app/package-lock.json
+++ b/web-app/package-lock.json
@@ -17,6 +17,7 @@
         "@typescript-eslint/parser": "^8.33.1",
         "@vitejs/plugin-vue": "^5.2.3",
         "@vitest/coverage-v8": "^3.2.1",
+        "@vue/test-utils": "^2.4.4",
         "@vue/tsconfig": "^0.7.0",
         "eslint": "^8.56.0",
         "eslint-plugin-vue": "^10.1.0",
@@ -946,6 +947,13 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@one-ini/wasm": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@one-ini/wasm/-/wasm-0.1.1.tgz",
+      "integrity": "sha512-XuySG1E38YScSJoMlqovLru4KTUNSjgVTIjyh7qMX6aNN5HY5Ct5LhRJdxO79JtTzKfzV/bnWpz+zquYrISsvw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -1855,6 +1863,26 @@
       "integrity": "sha512-c/0fWy3Jw6Z8L9FmTyYfkpM5zklnqqa9+a6dz3DvONRKW2NEbh46BP0FHuLFSWi2TnQEtp91Z6zOWNrU6QiyPg==",
       "license": "MIT"
     },
+    "node_modules/@vue/test-utils": {
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/@vue/test-utils/-/test-utils-2.4.4.tgz",
+      "integrity": "sha512-8jkRxz8pNhClAf4Co4ZrpAoFISdvT3nuSkUlY6Ys6rmTpw3DMWG/X3mw3gQ7QJzgCZO9f+zuE2kW57fi09MW7Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-beautify": "^1.14.9",
+        "vue-component-type-helpers": "^1.8.21"
+      },
+      "peerDependencies": {
+        "@vue/server-renderer": "^3.0.1",
+        "vue": "^3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "@vue/server-renderer": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@vue/tsconfig": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/@vue/tsconfig/-/tsconfig-0.7.0.tgz",
@@ -1872,6 +1900,16 @@
         "vue": {
           "optional": true
         }
+      }
+    },
+    "node_modules/abbrev": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-2.0.0.tgz",
+      "integrity": "sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/acorn": {
@@ -2133,12 +2171,33 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/commander": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/config-chain": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.13.tgz",
+      "integrity": "sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ini": "^1.3.4",
+        "proto-list": "~1.2.1"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -2270,6 +2329,41 @@
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/editorconfig": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/editorconfig/-/editorconfig-1.0.4.tgz",
+      "integrity": "sha512-L9Qe08KWTlqYMVvMcTIvMAdl1cDUubzRNYL+WfA4bLDMHe4nemKkpmYzkznE1FwLKu0EEmy6obgQKzMJrg4x9Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@one-ini/wasm": "0.1.1",
+        "commander": "^10.0.0",
+        "minimatch": "9.0.1",
+        "semver": "^7.5.3"
+      },
+      "bin": {
+        "editorconfig": "bin/editorconfig"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/editorconfig/node_modules/minimatch": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.1.tgz",
+      "integrity": "sha512-0jWhJpD/MdhPXwPuiRkCbfYfSKp2qnn2eOc279qI7f+osl/l+prKSrvhg157zSYvx/1nmgn2NqdT6k2Z7zSH9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
     },
     "node_modules/emoji-regex": {
       "version": "9.2.2",
@@ -3032,6 +3126,13 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -3167,6 +3268,38 @@
       },
       "optionalDependencies": {
         "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/js-beautify": {
+      "version": "1.15.4",
+      "resolved": "https://registry.npmjs.org/js-beautify/-/js-beautify-1.15.4.tgz",
+      "integrity": "sha512-9/KXeZUKKJwqCXUdBxFJ3vPh467OCckSBmYDwSK/EtV090K+iMJ7zx2S3HLVDIWFQdqMIsZWbnaGiba18aWhaA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "config-chain": "^1.1.13",
+        "editorconfig": "^1.0.4",
+        "glob": "^10.4.2",
+        "js-cookie": "^3.0.5",
+        "nopt": "^7.2.1"
+      },
+      "bin": {
+        "css-beautify": "js/bin/css-beautify.js",
+        "html-beautify": "js/bin/html-beautify.js",
+        "js-beautify": "js/bin/js-beautify.js"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/js-cookie": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.5.tgz",
+      "integrity": "sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/js-tokens": {
@@ -3458,6 +3591,22 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/nopt": {
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-7.2.1.tgz",
+      "integrity": "sha512-taM24ViiimT/XntxbPyJQzCG+p4EKOpgD3mxFwW38mGjVUrfERQOeY4EDHjdnptttfHuHQXFx+lTP08Q+mLa/w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "abbrev": "^2.0.0"
+      },
+      "bin": {
+        "nopt": "bin/nopt.js"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
     "node_modules/nth-check": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
@@ -3725,6 +3874,13 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/proto-list": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
+      "integrity": "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/punycode": {
       "version": "2.3.1",
@@ -4565,6 +4721,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/vue-component-type-helpers": {
+      "version": "1.8.27",
+      "resolved": "https://registry.npmjs.org/vue-component-type-helpers/-/vue-component-type-helpers-1.8.27.tgz",
+      "integrity": "sha512-0vOfAtI67UjeO1G6UiX5Kd76CqaQ67wrRZiOe7UAb9Jm6GzlUr/fC7CV90XfwapJRjpCMaZFhv1V0ajWRmE9Dg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/vue-eslint-parser": {
       "version": "10.1.3",

--- a/web-app/package.json
+++ b/web-app/package.json
@@ -20,6 +20,7 @@
     "@typescript-eslint/parser": "^8.33.1",
     "@vitejs/plugin-vue": "^5.2.3",
     "@vitest/coverage-v8": "^3.2.1",
+    "@vue/test-utils": "^2.4.4",
     "@vue/tsconfig": "^0.7.0",
     "eslint": "^8.56.0",
     "eslint-plugin-vue": "^10.1.0",

--- a/web-app/tests/DetailPage.test.ts
+++ b/web-app/tests/DetailPage.test.ts
@@ -1,0 +1,27 @@
+import { mount } from '@vue/test-utils';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+let mockSymbol: string | undefined;
+vi.mock('vue-router', () => ({
+  useRoute: () => ({ params: { symbol: mockSymbol } })
+}));
+
+import DetailPage from '../src/pages/DetailPage.vue';
+
+describe('DetailPage', () => {
+  beforeEach(() => {
+    mockSymbol = 'AAA';
+  });
+
+  it('displays symbol from route params', () => {
+    mockSymbol = 'XYZ';
+    const wrapper = mount(DetailPage);
+    expect(wrapper.text()).toContain('Symbol: XYZ');
+  });
+
+  it('does not display a different symbol', () => {
+    mockSymbol = 'DEF';
+    const wrapper = mount(DetailPage);
+    expect(wrapper.text()).not.toContain('Symbol: XYZ');
+  });
+});

--- a/web-app/tests/HeadlineCard.test.ts
+++ b/web-app/tests/HeadlineCard.test.ts
@@ -1,0 +1,37 @@
+import { mount, flushPromises } from '@vue/test-utils';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+let mockGetQuote: any;
+vi.mock('../src/services/MarketstackService', () => ({
+  MarketstackService: class {
+    getQuote(symbol: string) {
+      return mockGetQuote(symbol);
+    }
+  }
+}));
+
+import HeadlineCard from '../src/components/HeadlineCard.vue';
+
+const sampleQuote = { symbol: 'AAPL', date: '2024-01-01', close: 1.5 } as const;
+
+describe('HeadlineCard', () => {
+  beforeEach(() => {
+    mockGetQuote = vi.fn();
+  });
+
+  it('renders quote when service succeeds', async () => {
+    mockGetQuote.mockResolvedValue(sampleQuote);
+    const wrapper = mount(HeadlineCard);
+    await flushPromises();
+    expect(wrapper.text()).toContain('AAPL 1.5');
+    expect(wrapper.text()).not.toContain('Loading...');
+  });
+
+  it('shows placeholder when service fails', async () => {
+    mockGetQuote.mockResolvedValue(null);
+    const wrapper = mount(HeadlineCard);
+    await flushPromises();
+    expect(wrapper.text()).toContain('Loading...');
+    expect(wrapper.find('.headline-card').exists()).toBe(false);
+  });
+});

--- a/web-app/tests/MainPage.test.ts
+++ b/web-app/tests/MainPage.test.ts
@@ -1,0 +1,15 @@
+import { mount } from '@vue/test-utils';
+import { describe, it, expect } from 'vitest';
+import MainPage from '../src/pages/MainPage.vue';
+
+describe('MainPage', () => {
+  it('shows main heading', () => {
+    const wrapper = mount(MainPage);
+    expect(wrapper.find('h1').text()).toBe('Main Page');
+  });
+
+  it('does not contain search text', () => {
+    const wrapper = mount(MainPage);
+    expect(wrapper.text()).not.toContain('Search Page');
+  });
+});

--- a/web-app/tests/NewsPricesPage.test.ts
+++ b/web-app/tests/NewsPricesPage.test.ts
@@ -1,0 +1,15 @@
+import { mount } from '@vue/test-utils';
+import { describe, it, expect } from 'vitest';
+import NewsPricesPage from '../src/pages/NewsPricesPage.vue';
+
+describe('NewsPricesPage', () => {
+  it('renders news & prices heading', () => {
+    const wrapper = mount(NewsPricesPage);
+    expect(wrapper.find('h1').text()).toBe('News & Prices');
+  });
+
+  it('does not contain portfolio text', () => {
+    const wrapper = mount(NewsPricesPage);
+    expect(wrapper.text()).not.toContain('Portfolio Page');
+  });
+});

--- a/web-app/tests/PortfolioPage.test.ts
+++ b/web-app/tests/PortfolioPage.test.ts
@@ -1,0 +1,15 @@
+import { mount } from '@vue/test-utils';
+import { describe, it, expect } from 'vitest';
+import PortfolioPage from '../src/pages/PortfolioPage.vue';
+
+describe('PortfolioPage', () => {
+  it('renders portfolio heading', () => {
+    const wrapper = mount(PortfolioPage);
+    expect(wrapper.find('h1').text()).toBe('Portfolio Page');
+  });
+
+  it('does not contain pro text', () => {
+    const wrapper = mount(PortfolioPage);
+    expect(wrapper.text()).not.toContain('Pro Page');
+  });
+});

--- a/web-app/tests/ProPage.test.ts
+++ b/web-app/tests/ProPage.test.ts
@@ -1,0 +1,15 @@
+import { mount } from '@vue/test-utils';
+import { describe, it, expect } from 'vitest';
+import ProPage from '../src/pages/ProPage.vue';
+
+describe('ProPage', () => {
+  it('renders pro heading', () => {
+    const wrapper = mount(ProPage);
+    expect(wrapper.find('h1').text()).toBe('Pro Page');
+  });
+
+  it('does not contain main text', () => {
+    const wrapper = mount(ProPage);
+    expect(wrapper.text()).not.toContain('Main Page');
+  });
+});

--- a/web-app/tests/SearchPage.test.ts
+++ b/web-app/tests/SearchPage.test.ts
@@ -1,0 +1,15 @@
+import { mount } from '@vue/test-utils';
+import { describe, it, expect } from 'vitest';
+import SearchPage from '../src/pages/SearchPage.vue';
+
+describe('SearchPage', () => {
+  it('renders search heading', () => {
+    const wrapper = mount(SearchPage);
+    expect(wrapper.find('h1').text()).toBe('Search Page');
+  });
+
+  it('does not contain main text', () => {
+    const wrapper = mount(SearchPage);
+    expect(wrapper.text()).not.toContain('Main Page');
+  });
+});


### PR DESCRIPTION
## Summary
- add Vitest tests for HeadlineCard component
- add simple page tests
- add @vue/test-utils as a dev dependency

## Testing
- `npm run lint --silent` *(fails: no-unused-vars in existing files)*
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684041bef37883259b9dc2342e381387