### PR TITLE
Add optional symbol route in Flutter app

### DIFF
--- a/mobile-app/lib/main.dart
+++ b/mobile-app/lib/main.dart
@@ -16,14 +16,29 @@ class SmwaApp extends StatelessWidget {
     return MaterialApp(
       title: 'SMWA',
       initialRoute: '/',
-      routes: {
-        '/': (_) => const MainScreen(),
-        '/news': (_) => const NewsScreen(),
-        '/detail': (_) => const DetailScreen(),
-        '/auth': (_) => const AuthScreen(),
-        '/portfolio': (_) => const PortfolioScreen(),
-        '/pro': (_) => const ProScreen(),
-      },
+      onGenerateRoute: generateRoute,
     );
   }
+}
+
+/// Generates routes with optional parameters.
+Route<dynamic>? generateRoute(RouteSettings settings) {
+  final uri = Uri.parse(settings.name ?? '/');
+  final path = uri.pathSegments.isEmpty ? '/' : '/${uri.pathSegments.first}';
+  switch (path) {
+    case '/':
+      return MaterialPageRoute(builder: (_) => const MainScreen());
+    case '/news':
+      return MaterialPageRoute(builder: (_) => const NewsScreen());
+    case '/detail':
+      final symbol = uri.pathSegments.length > 1 ? uri.pathSegments[1] : null;
+      return MaterialPageRoute(builder: (_) => DetailScreen(symbol: symbol));
+    case '/auth':
+      return MaterialPageRoute(builder: (_) => const AuthScreen());
+    case '/portfolio':
+      return MaterialPageRoute(builder: (_) => const PortfolioScreen());
+    case '/pro':
+      return MaterialPageRoute(builder: (_) => const ProScreen());
+  }
+  return null;
 }

--- a/mobile-app/lib/screens/detail/detail_screen.dart
+++ b/mobile-app/lib/screens/detail/detail_screen.dart
@@ -1,12 +1,21 @@
 import 'package:flutter/material.dart';
 
+/// Shows a detail view for a stock symbol if provided.
 class DetailScreen extends StatelessWidget {
-  const DetailScreen({super.key});
+  /// The optional stock symbol to display.
+  final String? symbol;
+
+  /// Creates a [DetailScreen].
+  const DetailScreen({this.symbol, super.key});
 
   @override
   Widget build(BuildContext context) {
-    return const Scaffold(
-      body: Center(child: Text('Detail Screen')),
+    return Scaffold(
+      body: Center(
+        child: Text(
+          symbol != null ? 'Detail Screen ($symbol)' : 'Detail Screen',
+        ),
+      ),
     );
   }
 }

--- a/mobile-app/test/detail_screen_test.dart
+++ b/mobile-app/test/detail_screen_test.dart
@@ -4,9 +4,16 @@ import 'package:mobile_app/screens/detail/detail_screen.dart';
 
 void main() {
   group('DetailScreen', () {
-    testWidgets('shows expected text', (tester) async {
+    testWidgets('shows expected text when no symbol', (tester) async {
       await tester.pumpWidget(const MaterialApp(home: DetailScreen()));
       expect(find.text('Detail Screen'), findsOneWidget);
+    });
+
+    testWidgets('shows symbol when provided', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(home: DetailScreen(symbol: 'ABC')),
+      );
+      expect(find.text('Detail Screen (ABC)'), findsOneWidget);
     });
 
     testWidgets('does not show wrong text', (tester) async {

--- a/mobile-app/test/generate_route_test.dart
+++ b/mobile-app/test/generate_route_test.dart
@@ -1,0 +1,32 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobile_app/main.dart';
+
+void main() {
+  group('generateRoute', () {
+    testWidgets('resolves detail route with symbol', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(onGenerateRoute: generateRoute, initialRoute: '/'),
+      );
+      Navigator.pushNamed(
+        tester.element(find.byType(MaterialApp)),
+        '/detail/ABC',
+      );
+      await tester.pumpAndSettle();
+      expect(find.text('Detail Screen (ABC)'), findsOneWidget);
+    });
+
+    testWidgets('throws for unknown route', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(onGenerateRoute: generateRoute, initialRoute: '/'),
+      );
+      expect(
+        () => Navigator.pushNamed(
+          tester.element(find.byType(MaterialApp)),
+          '/no-route',
+        ),
+        throwsA(isA<Exception>()),
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- parse optional symbol in `/detail` routes
- display symbol on DetailScreen when provided
- adjust tests for new DetailScreen behaviour
- test route generation for optional symbols

## Testing
- `npm test`
- `npx eslint --fix src`
- `dart format lib test` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684041b5f6bc83259cd41075e1a8d8f5