### PR TITLE
Add lints and document analysis

### DIFF
--- a/CODING_RULES.md
+++ b/CODING_RULES.md
@@ -21,6 +21,8 @@
 
 ## Environment & config
 16. Runtime config ONLY via env-vars / secrets manager – `VITE_MARKETSTACK_KEY`, `VITE_NEWSDATA_KEY`, etc.
-17. Lint-defined code style: 2-space indent, single quotes, trailing newline.
+17. Lint-defined code style: 2-space indent, single quotes, trailing newline. The
+    lint rules live in `mobile-app/analysis_options.yaml` and are checked via
+    `flutter analyze`.
 
 *(CI enforces CVE scans, licence checks, coverage threshold, and prettier formatting – see `.github/workflows/`.)*

--- a/mobile-app/analysis_options.yaml
+++ b/mobile-app/analysis_options.yaml
@@ -1,4 +1,13 @@
-include: package:lints/recommended.yaml
+include: package:flutter_lints/flutter.yaml
+
+linter:
+  rules:
+    avoid_print: true
+    prefer_const_constructors: true
+    prefer_const_constructors_in_immutables: true
+    prefer_final_locals: true
+    prefer_single_quotes: true
+    newline_at_end_of_file: true
 
 analyzer:
   plugins:

--- a/mobile-app/pubspec.yaml
+++ b/mobile-app/pubspec.yaml
@@ -8,5 +8,10 @@ dependencies:
   flutter:
     sdk: flutter
 
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+  flutter_lints: ^3.0.1
+
 flutter:
   uses-material-design: true


### PR DESCRIPTION
## Summary
- document where lint rules live
- add `flutter_lints` and new analysis rules
- enable analyzer rules that discourage prints and enforce const constructors

## Testing
- `dart format --output none --set-exit-if-changed .` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*
- `npx eslint '{src,tests}/**/*.{js,ts,vue}' --fix`
- `npm test` *(interactive, aborted)*

------
https://chatgpt.com/codex/tasks/task_e_684041aceb5c832586fee902f8428161