### PR TITLE
Align NewsService with updated OpenAPI spec

### DIFF
--- a/packages/generated-dart/.openapi-generator/FILES
+++ b/packages/generated-dart/.openapi-generator/FILES
@@ -1,5 +1,4 @@
 .gitignore
-.openapi-generator-ignore
 README.md
 analysis_options.yaml
 doc/DefaultApi.md
@@ -20,6 +19,3 @@ lib/src/model/news_article.dart
 lib/src/model/quote.dart
 lib/src/serializers.dart
 pubspec.yaml
-test/default_api_test.dart
-test/news_article_test.dart
-test/quote_test.dart

--- a/packages/generated-dart/doc/NewsArticle.md
+++ b/packages/generated-dart/doc/NewsArticle.md
@@ -10,6 +10,8 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **title** | **String** |  | 
 **url** | **String** |  | 
+**source_** | **String** |  | 
+**published** | [**DateTime**](DateTime.md) |  | 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/packages/generated-dart/doc/Quote.md
+++ b/packages/generated-dart/doc/Quote.md
@@ -10,6 +10,10 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **symbol** | **String** |  | 
 **price** | **double** |  | 
+**open** | **double** |  | 
+**high** | **double** |  | 
+**low** | **double** |  | 
+**close** | **double** |  | 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/packages/generated-dart/lib/src/model/news_article.dart
+++ b/packages/generated-dart/lib/src/model/news_article.dart
@@ -13,6 +13,8 @@ part 'news_article.g.dart';
 /// Properties:
 /// * [title] 
 /// * [url] 
+/// * [source_] 
+/// * [published] 
 @BuiltValue()
 abstract class NewsArticle implements Built<NewsArticle, NewsArticleBuilder> {
   @BuiltValueField(wireName: r'title')
@@ -20,6 +22,12 @@ abstract class NewsArticle implements Built<NewsArticle, NewsArticleBuilder> {
 
   @BuiltValueField(wireName: r'url')
   String get url;
+
+  @BuiltValueField(wireName: r'source')
+  String get source_;
+
+  @BuiltValueField(wireName: r'published')
+  DateTime get published;
 
   NewsArticle._();
 
@@ -53,6 +61,16 @@ class _$NewsArticleSerializer implements PrimitiveSerializer<NewsArticle> {
     yield serializers.serialize(
       object.url,
       specifiedType: const FullType(String),
+    );
+    yield r'source';
+    yield serializers.serialize(
+      object.source_,
+      specifiedType: const FullType(String),
+    );
+    yield r'published';
+    yield serializers.serialize(
+      object.published,
+      specifiedType: const FullType(DateTime),
     );
   }
 
@@ -90,6 +108,20 @@ class _$NewsArticleSerializer implements PrimitiveSerializer<NewsArticle> {
             specifiedType: const FullType(String),
           ) as String;
           result.url = valueDes;
+          break;
+        case r'source':
+          final valueDes = serializers.deserialize(
+            value,
+            specifiedType: const FullType(String),
+          ) as String;
+          result.source_ = valueDes;
+          break;
+        case r'published':
+          final valueDes = serializers.deserialize(
+            value,
+            specifiedType: const FullType(DateTime),
+          ) as DateTime;
+          result.published = valueDes;
           break;
         default:
           unhandled.add(key);

--- a/packages/generated-dart/lib/src/model/quote.dart
+++ b/packages/generated-dart/lib/src/model/quote.dart
@@ -13,6 +13,10 @@ part 'quote.g.dart';
 /// Properties:
 /// * [symbol] 
 /// * [price] 
+/// * [open] 
+/// * [high] 
+/// * [low] 
+/// * [close] 
 @BuiltValue()
 abstract class Quote implements Built<Quote, QuoteBuilder> {
   @BuiltValueField(wireName: r'symbol')
@@ -20,6 +24,18 @@ abstract class Quote implements Built<Quote, QuoteBuilder> {
 
   @BuiltValueField(wireName: r'price')
   double get price;
+
+  @BuiltValueField(wireName: r'open')
+  double get open;
+
+  @BuiltValueField(wireName: r'high')
+  double get high;
+
+  @BuiltValueField(wireName: r'low')
+  double get low;
+
+  @BuiltValueField(wireName: r'close')
+  double get close;
 
   Quote._();
 
@@ -52,6 +68,26 @@ class _$QuoteSerializer implements PrimitiveSerializer<Quote> {
     yield r'price';
     yield serializers.serialize(
       object.price,
+      specifiedType: const FullType(double),
+    );
+    yield r'open';
+    yield serializers.serialize(
+      object.open,
+      specifiedType: const FullType(double),
+    );
+    yield r'high';
+    yield serializers.serialize(
+      object.high,
+      specifiedType: const FullType(double),
+    );
+    yield r'low';
+    yield serializers.serialize(
+      object.low,
+      specifiedType: const FullType(double),
+    );
+    yield r'close';
+    yield serializers.serialize(
+      object.close,
       specifiedType: const FullType(double),
     );
   }
@@ -90,6 +126,34 @@ class _$QuoteSerializer implements PrimitiveSerializer<Quote> {
             specifiedType: const FullType(double),
           ) as double;
           result.price = valueDes;
+          break;
+        case r'open':
+          final valueDes = serializers.deserialize(
+            value,
+            specifiedType: const FullType(double),
+          ) as double;
+          result.open = valueDes;
+          break;
+        case r'high':
+          final valueDes = serializers.deserialize(
+            value,
+            specifiedType: const FullType(double),
+          ) as double;
+          result.high = valueDes;
+          break;
+        case r'low':
+          final valueDes = serializers.deserialize(
+            value,
+            specifiedType: const FullType(double),
+          ) as double;
+          result.low = valueDes;
+          break;
+        case r'close':
+          final valueDes = serializers.deserialize(
+            value,
+            specifiedType: const FullType(double),
+          ) as double;
+          result.close = valueDes;
           break;
         default:
           unhandled.add(key);

--- a/packages/generated-ts/.openapi-generator/FILES
+++ b/packages/generated-ts/.openapi-generator/FILES
@@ -1,4 +1,3 @@
-.openapi-generator-ignore
 apis/DefaultApi.ts
 apis/index.ts
 index.ts

--- a/packages/generated-ts/models/NewsArticle.ts
+++ b/packages/generated-ts/models/NewsArticle.ts
@@ -31,6 +31,18 @@ export interface NewsArticle {
      * @memberof NewsArticle
      */
     url: string;
+    /**
+     * 
+     * @type {string}
+     * @memberof NewsArticle
+     */
+    source: string;
+    /**
+     * 
+     * @type {Date}
+     * @memberof NewsArticle
+     */
+    published: Date;
 }
 
 /**
@@ -39,6 +51,8 @@ export interface NewsArticle {
 export function instanceOfNewsArticle(value: object): value is NewsArticle {
     if (!('title' in value) || value['title'] === undefined) return false;
     if (!('url' in value) || value['url'] === undefined) return false;
+    if (!('source' in value) || value['source'] === undefined) return false;
+    if (!('published' in value) || value['published'] === undefined) return false;
     return true;
 }
 
@@ -54,6 +68,8 @@ export function NewsArticleFromJSONTyped(json: any, ignoreDiscriminator: boolean
         
         'title': json['title'],
         'url': json['url'],
+        'source': json['source'],
+        'published': (new Date(json['published'])),
     };
 }
 
@@ -70,6 +86,8 @@ export function NewsArticleToJSONTyped(value?: NewsArticle | null, ignoreDiscrim
         
         'title': value['title'],
         'url': value['url'],
+        'source': value['source'],
+        'published': ((value['published']).toISOString()),
     };
 }
 

--- a/packages/generated-ts/models/Quote.ts
+++ b/packages/generated-ts/models/Quote.ts
@@ -31,6 +31,30 @@ export interface Quote {
      * @memberof Quote
      */
     price: number;
+    /**
+     * 
+     * @type {number}
+     * @memberof Quote
+     */
+    open: number;
+    /**
+     * 
+     * @type {number}
+     * @memberof Quote
+     */
+    high: number;
+    /**
+     * 
+     * @type {number}
+     * @memberof Quote
+     */
+    low: number;
+    /**
+     * 
+     * @type {number}
+     * @memberof Quote
+     */
+    close: number;
 }
 
 /**
@@ -39,6 +63,10 @@ export interface Quote {
 export function instanceOfQuote(value: object): value is Quote {
     if (!('symbol' in value) || value['symbol'] === undefined) return false;
     if (!('price' in value) || value['price'] === undefined) return false;
+    if (!('open' in value) || value['open'] === undefined) return false;
+    if (!('high' in value) || value['high'] === undefined) return false;
+    if (!('low' in value) || value['low'] === undefined) return false;
+    if (!('close' in value) || value['close'] === undefined) return false;
     return true;
 }
 
@@ -54,6 +82,10 @@ export function QuoteFromJSONTyped(json: any, ignoreDiscriminator: boolean): Quo
         
         'symbol': json['symbol'],
         'price': json['price'],
+        'open': json['open'],
+        'high': json['high'],
+        'low': json['low'],
+        'close': json['close'],
     };
 }
 
@@ -70,6 +102,10 @@ export function QuoteToJSONTyped(value?: Quote | null, ignoreDiscriminator: bool
         
         'symbol': value['symbol'],
         'price': value['price'],
+        'open': value['open'],
+        'high': value['high'],
+        'low': value['low'],
+        'close': value['close'],
     };
 }
 

--- a/packages/openapi.yaml
+++ b/packages/openapi.yaml
@@ -67,4 +67,9 @@ components:
           type: string
         url:
           type: string
-      required: [title, url]
+        source:
+          type: string
+        published:
+          type: string
+          format: date-time
+      required: [title, url, source, published]

--- a/web-app/src/services/MarketstackService.ts
+++ b/web-app/src/services/MarketstackService.ts
@@ -18,7 +18,10 @@ const CACHE_TTL = 24 * 60 * 60 * 1000; // 24h
 export class MarketstackService {
   private cache = new LruCache<string, Quote>(32);
   private ledger = new ApiQuotaLedger(100);
-  constructor(private apiKey: string) {}
+  private apiKey: string;
+  constructor(apiKey: string) {
+    this.apiKey = apiKey;
+  }
 
   /**
    * Retrieve the latest quote for a given stock symbol.

--- a/web-app/src/services/NewsService.ts
+++ b/web-app/src/services/NewsService.ts
@@ -3,7 +3,7 @@ import { ApiQuotaLedger } from '@/utils/ApiQuotaLedger';
 
 export interface NewsArticle {
   title: string;
-  link: string;
+  url: string;
   source: string;
   published: string;
 }
@@ -16,7 +16,10 @@ const CACHE_TTL = 12 * 60 * 60 * 1000; // 12h
 export class NewsService {
   private cache = new LruCache<string, NewsArticle[]>(32);
   private ledger = new ApiQuotaLedger(200); // 200 req/day
-  constructor(private apiKey: string) {}
+  private apiKey: string;
+  constructor(apiKey: string) {
+    this.apiKey = apiKey;
+  }
 
   /**
    * Retrieve up to three recent articles about the given symbol.
@@ -41,7 +44,7 @@ export class NewsService {
         .slice(0, 3)
         .map((a: any) => ({
           title: a.title,
-          link: a.link,
+          url: a.link,
           source: a.source_id,
           published: a.pubDate,
         }));

--- a/web-app/src/utils/ApiQuotaLedger.ts
+++ b/web-app/src/utils/ApiQuotaLedger.ts
@@ -8,10 +8,12 @@
 export class ApiQuotaLedger {
   private rollingCount = 0;
   private windowStart = Date.now();
-  constructor(
-    private limit: number,
-    private windowMs = 24 * 60 * 60 * 1000,
-  ) {}
+  private limit: number;
+  private windowMs: number;
+  constructor(limit: number, windowMs = 24 * 60 * 60 * 1000) {
+    this.limit = limit;
+    this.windowMs = windowMs;
+  }
 
   /**
    * Increase the count for the current window.

--- a/web-app/tests/NewsService.test.ts
+++ b/web-app/tests/NewsService.test.ts
@@ -2,16 +2,16 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { NewsService, type NewsArticle } from '../src/services/NewsService';
 
 const sampleArticles: NewsArticle[] = [
-  { title: 't1', link: 'l1', source: 's1', published: 'p1' },
-  { title: 't2', link: 'l2', source: 's2', published: 'p2' },
-  { title: 't3', link: 'l3', source: 's3', published: 'p3' }
+  { title: 't1', url: 'l1', source: 's1', published: 'p1' },
+  { title: 't2', url: 'l2', source: 's2', published: 'p2' },
+  { title: 't3', url: 'l3', source: 's3', published: 'p3' }
 ];
 
 function apiPayload() {
   return {
     results: sampleArticles.map(a => ({
       title: a.title,
-      link: a.link,
+      link: a.url,
       source_id: a.source,
       pubDate: a.published
     }))


### PR DESCRIPTION
## Summary
- add `source` and `published` fields to `NewsArticle` schema
- regenerate TypeScript and Dart API clients
- use `url` instead of `link` in `NewsService`
- update tests for new article shape
- fix ESLint unused variable errors by storing API keys and limits on instances

## Testing
- `dart format -o none -l 120 -s mobile-app lib` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68404191f51483258fc585eb6f2882cd