### PR TITLE
Fix Vitest run mode

### DIFF
--- a/web-app/package.json
+++ b/web-app/package.json
@@ -7,7 +7,7 @@
     "dev": "vite",
     "build": "vue-tsc -b && vite build",
     "preview": "vite preview",
-    "test": "vitest",
+    "test": "vitest run",
     "lint": "eslint '{src,tests}/**/*.{js,ts,vue}' --fix"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- run vitest in single-run mode so CI exits cleanly

## Testing
- `npm run lint`
- `npm test`
- `dart format` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684048c8314c83259ebac9cf8bfb27b4