### PR TITLE
Fix typed ImportMeta usage and map results

### DIFF
--- a/web-app/src/utils/logMetrics.ts
+++ b/web-app/src/utils/logMetrics.ts
@@ -6,7 +6,7 @@ export function isDev(): boolean {
     return process.env.NODE_ENV !== 'production';
   }
   try {
-    return Boolean((import.meta as any).env?.DEV);
+    return Boolean((import.meta as ImportMeta).env?.DEV);
   } catch {
     return false;
   }


### PR DESCRIPTION
## Summary
- update `isDev` to rely on typed `ImportMeta`
- type NewsService API mapping

## Testing
- `npm run lint`
- `npx vitest run`
- `dart format` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684048bfae7c83259bd22afec5a18aa6