### PR TITLE
Unify quote model for Marketstack

### DIFF
--- a/web-app/src/components/HeadlineCard.vue
+++ b/web-app/src/components/HeadlineCard.vue
@@ -1,7 +1,6 @@
 <template>
   <div v-if="quote" class="headline-card">
-    <h2>{{ quote.symbol }} {{ quote.close }}</h2>
-    <p>{{ quote.date }}</p>
+    <h2>{{ quote.symbol }} {{ quote.price }}</h2>
   </div>
   <p v-else>Loading...</p>
 </template>

--- a/web-app/src/services/MarketstackService.ts
+++ b/web-app/src/services/MarketstackService.ts
@@ -1,15 +1,10 @@
 import { LruCache } from '@/utils/LruCache';
 import { ApiQuotaLedger } from '@/utils/ApiQuotaLedger';
 import { logApiCall } from '@/utils/logMetrics';
+import type { Quote } from '../../../packages/generated-ts/models/Quote';
 
-export interface Quote {
-  symbol: string;
-  date: string;
-  open: number;
-  high: number;
-  low: number;
-  close: number;
-}
+export type { Quote };
+
 
 const CACHE_TTL = 24 * 60 * 60 * 1000; // 24h
 
@@ -46,7 +41,15 @@ export class MarketstackService {
       if (!resp.ok) return null;
       this.ledger.increment();
       const data = await resp.json();
-      const quote: Quote = data.data[0];
+      const raw = data.data[0];
+      const quote: Quote = {
+        symbol: raw.symbol,
+        price: raw.close,
+        open: raw.open,
+        high: raw.high,
+        low: raw.low,
+        close: raw.close
+      };
       this.cache.put(symbol, quote, CACHE_TTL);
       return quote;
     } catch {

--- a/web-app/tests/HeadlineCard.test.ts
+++ b/web-app/tests/HeadlineCard.test.ts
@@ -12,7 +12,7 @@ vi.mock('../src/services/MarketstackService', () => ({
 
 const sampleQuote: Quote = {
   symbol: 'AAPL',
-  date: '2024-01-01',
+  price: 1.5,
   open: 1,
   high: 2,
   low: 0.5,

--- a/web-app/tests/MarketstackService.test.ts
+++ b/web-app/tests/MarketstackService.test.ts
@@ -1,9 +1,17 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { MarketstackService, type Quote } from '../src/services/MarketstackService';
 
+const sampleApiQuote = {
+  symbol: 'AAPL',
+  open: 1,
+  high: 2,
+  low: 0.5,
+  close: 1.5
+};
+
 const sampleQuote: Quote = {
   symbol: 'AAPL',
-  date: '2024-01-01',
+  price: 1.5,
   open: 1,
   high: 2,
   low: 0.5,
@@ -24,7 +32,7 @@ describe('MarketstackService', () => {
     const ledger = { isSafe: vi.fn().mockReturnValue(true), increment: vi.fn() };
     (service as any).ledger = ledger;
 
-    const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: async () => ({ data: [sampleQuote] }) });
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: async () => ({ data: [sampleApiQuote] }) });
     global.fetch = fetchMock as any;
 
     const first = await service.getQuote('AAPL');
@@ -56,7 +64,7 @@ describe('MarketstackService', () => {
     const fetchMock = vi
       .fn()
       .mockResolvedValueOnce({ ok: false })
-      .mockResolvedValueOnce({ ok: true, json: async () => ({ data: [sampleQuote] }) });
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ data: [sampleApiQuote] }) });
     global.fetch = fetchMock as any;
 
     const fail = await service.getQuote('AAPL');
@@ -74,10 +82,11 @@ describe('MarketstackService', () => {
     const ledger = { isSafe: vi.fn().mockReturnValue(true), increment: vi.fn() };
     (service as any).ledger = ledger;
     const quoteB: Quote = { ...sampleQuote, symbol: 'IBM' };
+    const apiQuoteB = { ...sampleApiQuote, symbol: 'IBM' };
     const fetchMock = vi
       .fn()
-      .mockResolvedValueOnce({ ok: true, json: async () => ({ data: [sampleQuote] }) })
-      .mockResolvedValueOnce({ ok: true, json: async () => ({ data: [quoteB] }) });
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ data: [sampleApiQuote] }) })
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ data: [apiQuoteB] }) });
     global.fetch = fetchMock as any;
 
     const first = await service.getQuote('AAPL');


### PR DESCRIPTION
## Summary
- reuse generated `Quote` type in MarketstackService
- show price in HeadlineCard
- adjust unit tests for new quote shape

## Testing
- `npm run lint`
- `npm test`
- `dart format -o none **/*.dart` *(fails: `bash: dart: command not found`)*
- `flutter analyze` *(fails: `bash: flutter: command not found`)*
- `flutter test` *(fails: `bash: flutter: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684048c500c8832590065d29df1524b4