### PR TITLE
Validate service API keys

### DIFF
--- a/web-app/src/services/MarketstackService.ts
+++ b/web-app/src/services/MarketstackService.ts
@@ -21,6 +21,9 @@ export class MarketstackService {
   private ledger = new ApiQuotaLedger(100);
   private apiKey: string;
   constructor(apiKey: string) {
+    if (typeof apiKey !== 'string' || apiKey.trim() === '') {
+      throw new Error('Marketstack API key is required');
+    }
     this.apiKey = apiKey;
   }
 

--- a/web-app/src/services/NewsService.ts
+++ b/web-app/src/services/NewsService.ts
@@ -19,6 +19,9 @@ export class NewsService {
   private ledger = new ApiQuotaLedger(200); // 200 req/day
   private apiKey: string;
   constructor(apiKey: string) {
+    if (typeof apiKey !== 'string' || apiKey.trim() === '') {
+      throw new Error('Newsdata API key is required');
+    }
     this.apiKey = apiKey;
   }
 

--- a/web-app/tests/LruCache.test.ts
+++ b/web-app/tests/LruCache.test.ts
@@ -10,9 +10,9 @@ describe('LruCache', () => {
 
   it('expires after TTL', async () => {
     const cache = new LruCache<string, number>(1);
-    cache.put('a', 1, 1);
+    cache.put('a', 1, 5);
     expect(cache.get('a')).toBe(1);
-    await new Promise(r => setTimeout(r, 5));
+    await new Promise(r => setTimeout(r, 10));
     expect(cache.get('a')).toBeUndefined();
   });
 

--- a/web-app/tests/MarketstackService.test.ts
+++ b/web-app/tests/MarketstackService.test.ts
@@ -19,6 +19,10 @@ describe('MarketstackService', () => {
     vi.restoreAllMocks();
   });
 
+  it('throws for empty API key', () => {
+    expect(() => new MarketstackService('')).toThrow();
+  });
+
   it('fetches quote and caches result', async () => {
     const service = new MarketstackService('k');
     const ledger = { isSafe: vi.fn().mockReturnValue(true), increment: vi.fn() };

--- a/web-app/tests/NewsService.test.ts
+++ b/web-app/tests/NewsService.test.ts
@@ -26,6 +26,10 @@ describe('NewsService', () => {
     vi.restoreAllMocks();
   });
 
+  it('throws for empty API key', () => {
+    expect(() => new NewsService('')).toThrow();
+  });
+
   it('fetches news and caches result', async () => {
     const service = new NewsService('key');
     const ledger = { isSafe: vi.fn().mockReturnValue(true), increment: vi.fn() };


### PR DESCRIPTION
## Summary
- ensure MarketstackService and NewsService require API keys
- cover new validation cases in unit tests
- stabilize LruCache TTL test

## Testing
- `npm run lint`
- `npx vitest run`
- `dart format -o none --set-exit-if-changed **/*.dart` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684048c1327083258da3723c4acbfa03