### PR TITLE
Add consolidated API spec and generation script

### DIFF
--- a/packages/package.json
+++ b/packages/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "gen:ts": "npx @openapitools/openapi-generator-cli generate -i openapi.yaml -g typescript-fetch -o generated-ts",
-    "gen:dart": "npx @openapitools/openapi-generator-cli generate -i openapi.yaml -g dart-dio -o generated-dart"
+    "gen:dart": "npx @openapitools/openapi-generator-cli generate -i openapi.yaml -g dart-dio -o generated-dart",
+    "gen:all": "openapi-generator-cli generate -i ../spec/openapi.yaml -g typescript-axios -o generated"
   }
 }

--- a/spec/openapi.yaml
+++ b/spec/openapi.yaml
@@ -1,0 +1,137 @@
+openapi: 3.0.0
+info:
+  title: External Services
+  version: 1.0.0
+paths:
+  /eod:
+    get:
+      summary: Marketstack end of day quote
+      parameters:
+        - in: query
+          name: access_key
+          required: true
+          schema:
+            type: string
+        - in: query
+          name: symbols
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Quote data
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/Quote'
+  /latest:
+    get:
+      summary: Latest FX rate
+      parameters:
+        - in: query
+          name: base
+          required: true
+          schema:
+            type: string
+        - in: query
+          name: symbols
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: FX rate
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  rates:
+                    type: object
+                    additionalProperties:
+                      type: number
+                      format: double
+  /api/1/news:
+    get:
+      summary: NewsData search
+      parameters:
+        - in: query
+          name: apikey
+          required: true
+          schema:
+            type: string
+        - in: query
+          name: q
+          required: true
+          schema:
+            type: string
+        - in: query
+          name: language
+          required: false
+          schema:
+            type: string
+            default: en
+      responses:
+        '200':
+          description: News articles
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  results:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/NewsArticle'
+components:
+  schemas:
+    Quote:
+      type: object
+      properties:
+        symbol:
+          type: string
+        price:
+          type: number
+          format: double
+        open:
+          type: number
+          format: double
+        high:
+          type: number
+          format: double
+        low:
+          type: number
+          format: double
+        close:
+          type: number
+          format: double
+      required: [symbol, price, open, high, low, close]
+    FxRate:
+      type: object
+      properties:
+        base:
+          type: string
+        quote:
+          type: string
+        rate:
+          type: number
+          format: double
+      required: [base, quote, rate]
+    NewsArticle:
+      type: object
+      properties:
+        title:
+          type: string
+        url:
+          type: string
+        source:
+          type: string
+        published:
+          type: string
+          format: date-time
+      required: [title, url, source, published]


### PR DESCRIPTION
## Summary
- add `spec/openapi.yaml` merging endpoints for Marketstack, Exchangerate.host and NewsData
- add `gen:all` script to packages `package.json`
- run eslint and tests

## Testing
- `npm run lint --if-present`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68406161c1f483258a01424d7397ca69