### PR TITLE
Update documentation authority note

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ This repository hosts a cross-platform stock market app with a Flutter mobile fr
 
 # Important — Not authoritative:
 1. This file is only a quick-start contributor guide.
-2. For every requirement and/or design decision, the single source of truth is the documentation in /docs (SDD_v1.md, SRS_v1.md, original assignment - single source of truth).
+2. For any requirement or design decision, /docs (SRS_v1.md, SDD_v1.md, original_assignment.md) is the sole authority; this file is only a convenience summary.
 3. Always consult those documents first and treat AGENTS.md as secondary.
 
 ## Required Tools


### PR DESCRIPTION
## Summary
- update contributor guide to reference `/docs` as sole authority for requirements and decisions

## Testing
- `dart format --set-exit-if-changed .` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*
- `npx eslint --fix` *(fails: no ESLint config)*
- `npm test` *(fails: no package.json)*
- `npm test --silent` in `web-app`
- `npx eslint '{src,tests}/**/*.{js,ts,vue}' --fix` in `web-app`
- `npm test --silent` in `packages` *(fails: vitest not found)*
- `npx eslint '**/*.ts' --fix` in `packages` *(fails: no ESLint config)*
- `npm test --silent` in `schema`
- `npx eslint '**/*.js' --fix` in `schema` *(fails: no ESLint config)*
- `npm test --silent` in `web-app/design-tokens`
- `npx eslint '**/*.js' --fix` in `web-app/design-tokens` *(fails: lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_684086768e048325be0d2b799feb9d97