### PR TITLE
Add gen:clients helper script

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,10 +17,10 @@ This repository hosts a cross-platform stock market app with a Flutter mobile fr
 1. Clone the repo and generate REST clients:
    ```bash
    cd packages
-   npx @openapitools/openapi-generator-cli generate -i openapi.yaml -g typescript-fetch -o generated-ts
-   npx @openapitools/openapi-generator-cli generate -i openapi.yaml -g dart-dio -o generated-dart
+   npm run gen:clients
    cd ..
    ```
+   This script replaces running `npm run gen:ts` and `npm run gen:dart` separately.
 2. Mobile app:
    ```bash
    cd mobile-app

--- a/README.md
+++ b/README.md
@@ -53,8 +53,7 @@ cd Stock-App1
 
 # 2 · Generate REST clients
 cd packages
-npm run gen:ts   # TypeScript client
-npm run gen:dart # Dart client
+npm run gen:clients   # runs gen:ts and gen:dart
 cd ..
 
 # 3 · Mobile (Flutter)
@@ -92,7 +91,7 @@ Task	Mobile	Web
 Dev hot-reload	flutter run	npm run dev
 Unit tests	flutter test	npm test
 Lint / format	dart format .	npm run lint
-REST clients    –               npm run gen:ts && npm run gen:dart (in packages/)
+REST clients    –               npm run gen:clients (in packages/)
 Build (CI)	GitHub Action → Netlify preview	(same)
 `npm run lint` in `web-app/` runs ESLint with auto-fix enabled for all TypeScript and Vue files. The linter is configured via `eslint.config.js`, enforcing 2-space indentation and single quotes.
 

--- a/packages/README.md
+++ b/packages/README.md
@@ -4,9 +4,10 @@ This folder contains shared API contracts and generated clients for both
 web and mobile apps. `openapi.yaml` defines a minimal spec used to produce
 TypeScript and Dart client stubs.
 
-Run the following scripts from this directory:
+Run the following script from this directory to regenerate both REST clients:
 
 ```bash
-npm run gen:ts   # generates generated-ts/
-npm run gen:dart # generates generated-dart/
+npm run gen:clients
 ```
+
+This command replaces the previous `npm run gen:ts` and `npm run gen:dart` pair.

--- a/packages/package.json
+++ b/packages/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "gen:ts": "npx @openapitools/openapi-generator-cli generate -i openapi.yaml -g typescript-fetch -o generated-ts",
     "gen:dart": "npx @openapitools/openapi-generator-cli generate -i openapi.yaml -g dart-dio -o generated-dart",
+    "gen:clients": "npm run gen:ts && npm run gen:dart",
     "gen:all": "openapi-generator-cli generate -i ../spec/openapi.yaml -g typescript-axios -o generated",
     "lint:spec": "openapi-cli lint spec/openapi.yaml",
     "test": "vitest run"


### PR DESCRIPTION
## Summary
- add `gen:clients` helper script to run REST client generation
- update README and packages/README to use the new script
- revise AGENTS.md instructions accordingly

## Testing
- `dart format -o none .` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*
- `npm run lint` in `web-app`
- `npm test` in `web-app`
- `npm run lint:spec` in `packages` *(fails: openapi-cli not found)*
- `npm test` in `packages` *(fails: vitest not found)*
- `npm test` in `schema`


------
https://chatgpt.com/codex/tasks/task_e_684086675eac832589582c5db17c1922