### PR TITLE
Fix style-dictionary config module

### DIFF
--- a/web-app/design-tokens/package.json
+++ b/web-app/design-tokens/package.json
@@ -1,6 +1,7 @@
 {
   "name": "design-tokens",
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "style-dictionary build --config style-dictionary.config.js"
   },

--- a/web-app/design-tokens/style-dictionary.config.js
+++ b/web-app/design-tokens/style-dictionary.config.js
@@ -1,4 +1,4 @@
-const StyleDictionary = require('style-dictionary').default;
+import StyleDictionary from 'style-dictionary';
 
 function rgbaToHex(rgba) {
   const m = rgba.match(/rgba?\((\d+),\s*(\d+),\s*(\d+)(?:,\s*(\d*\.?\d+))?\)/);
@@ -37,7 +37,7 @@ StyleDictionary.registerFormat({
   }
 });
 
-module.exports = {
+export default {
   source: ['tokens.json'],
   platforms: {
     css: {


### PR DESCRIPTION
## Summary
- convert design-token builder config to ESM and mark package as module

## Testing
- `dart format -o none --set-exit-if-changed .`
- `flutter analyze` *(fails: undefined_function in tokens.dart)*
- `flutter test` *(fails: Test directory "test" not found)*
- `npm run lint` in `web-app`
- `npm test` in `web-app`


------
https://chatgpt.com/codex/tasks/task_e_6845b11e09048325a1419485379a042e