### PR TITLE
Implement top movers list

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -1,4 +1,11 @@
 
+## 2025-06-08 PR #76
+- **Summary**: added Marketstack getTopMovers, Pinia action and page lists with tests
+- **Stage**: In progress
+- **Requirements addressed**: N/A
+- **Deviations/Decisions**: none
+- **Next step**: expand store features
+
 ## 2025-06-08 PR #75
 - **Summary**: add fetchJson helper and refactor services; added tests
 - **Stage**: In progress

--- a/web-app/src/pages/NewsPricesPage.vue
+++ b/web-app/src/pages/NewsPricesPage.vue
@@ -1,6 +1,22 @@
 <template>
   <div class="page">
     <h1>News & Prices</h1>
+    <div v-if="store.topGainers.length">
+      <h2>Top Gainers</h2>
+      <ul>
+        <li v-for="g in store.topGainers" :key="g.symbol">
+          {{ g.symbol }} {{ g.price }}
+        </li>
+      </ul>
+    </div>
+    <div v-if="store.topLosers.length">
+      <h2>Top Losers</h2>
+      <ul>
+        <li v-for="l in store.topLosers" :key="l.symbol">
+          {{ l.symbol }} {{ l.price }}
+        </li>
+      </ul>
+    </div>
   </div>
 </template>
 
@@ -10,7 +26,8 @@ import { useAppStore } from '@/stores/appStore';
 import { onMounted } from 'vue';
 const store = useAppStore();
 
-onMounted(() => {
+onMounted(async () => {
+  await store.loadTopMovers();
   store.toggleCurrency();
 });
 

--- a/web-app/src/stores/appStore.ts
+++ b/web-app/src/stores/appStore.ts
@@ -10,6 +10,8 @@ export interface AppState {
   currency: string;
   isPro: boolean;
   searchResults: string[];
+  topGainers: Quote[];
+  topLosers: Quote[];
 }
 
 export interface AppDeps {
@@ -26,7 +28,9 @@ export function createAppStore(deps: AppDeps = {}) {
       articles: null,
       currency: 'USD',
       isPro: false,
-      searchResults: []
+      searchResults: [],
+      topGainers: [],
+      topLosers: []
     }),
     actions: {
       async loadHeadline(symbol: string = 'AAPL') {
@@ -38,6 +42,14 @@ export function createAppStore(deps: AppDeps = {}) {
           new NewsService(import.meta.env.VITE_NEWSDATA_KEY ?? '');
         this.headline = await quoteSvc.getQuote(symbol);
         this.articles = this.headline ? await newsSvc.getNews(symbol) : null;
+      },
+      async loadTopMovers() {
+        const quoteSvc =
+          deps.quoteService ??
+          new MarketstackService(import.meta.env.VITE_MARKETSTACK_KEY ?? '');
+        const res = await quoteSvc.getTopMovers();
+        this.topGainers = res?.gainers ?? [];
+        this.topLosers = res?.losers ?? [];
       },
       async toggleCurrency() {
         const target = this.currency === 'USD' ? 'EUR' : 'USD';

--- a/web-app/tests/Pages.test.ts
+++ b/web-app/tests/Pages.test.ts
@@ -9,15 +9,9 @@ import SearchPage from '../src/pages/SearchPage.vue';
 import PortfolioPage from '../src/pages/PortfolioPage.vue';
 import { useRoute } from 'vue-router';
 
+let storeMock: any;
 vi.mock('../src/stores/appStore', () => ({
-  useAppStore: () => ({
-    loadHeadline: vi.fn(),
-    toggleCurrency: vi.fn(),
-    signIn: vi.fn(),
-    search: vi.fn().mockReturnValue([]),
-    upgradePro: vi.fn(),
-    syncWatchList: vi.fn()
-  })
+  useAppStore: () => storeMock
 }));
 
 vi.mock('vue-router', () => ({ useRoute: vi.fn() }));
@@ -25,6 +19,17 @@ const mockedUseRoute = useRoute as unknown as ReturnType<typeof vi.fn>;
 
 beforeEach(() => {
   setActivePinia(createPinia());
+  storeMock = {
+    loadHeadline: vi.fn(),
+    loadTopMovers: vi.fn(),
+    toggleCurrency: vi.fn(),
+    signIn: vi.fn(),
+    search: vi.fn().mockReturnValue([]),
+    upgradePro: vi.fn(),
+    syncWatchList: vi.fn(),
+    topGainers: [],
+    topLosers: []
+  };
 });
 
 describe('MainPage', () => {
@@ -57,11 +62,21 @@ describe('NewsPricesPage', () => {
   it('renders heading', () => {
     const wrapper = mount(NewsPricesPage);
     expect(wrapper.find('h1').text()).toBe('News & Prices');
+    expect(storeMock.loadTopMovers).toHaveBeenCalled();
   });
 
-  it('no extra heading present', () => {
+  it('shows movers lists', () => {
+    storeMock.topGainers = [
+      { symbol: 'A', price: 1, open: 1, high: 1, low: 1, close: 1 }
+    ];
+    storeMock.topLosers = [
+      { symbol: 'B', price: 2, open: 2, high: 2, low: 2, close: 2 }
+    ];
     const wrapper = mount(NewsPricesPage);
-    expect(wrapper.find('h2').exists()).toBe(false);
+    expect(wrapper.text()).toContain('Top Gainers');
+    expect(wrapper.text()).toContain('A 1');
+    expect(wrapper.text()).toContain('Top Losers');
+    expect(wrapper.text()).toContain('B 2');
   });
 });
 

--- a/web-app/tests/appStore.test.ts
+++ b/web-app/tests/appStore.test.ts
@@ -80,4 +80,37 @@ describe('appStore', () => {
     store.upgradePro();
     expect(store.isPro).toBe(true);
   });
+
+  it('loads top movers', async () => {
+    const gainers: Quote[] = [
+      { symbol: 'A', price: 1, open: 1, high: 1, low: 1, close: 1 },
+    ];
+    const losers: Quote[] = [
+      { symbol: 'B', price: 2, open: 2, high: 2, low: 2, close: 2 },
+    ];
+    const getTopMovers = vi.fn().mockResolvedValue({ gainers, losers });
+    const store = createAppStore({
+      quoteService: { getTopMovers } as any,
+      newsService: { getNews: vi.fn() } as any,
+      fxService: { getRate: vi.fn() } as any,
+      trie: { search: vi.fn().mockReturnValue([]) } as any,
+    })();
+    await store.loadTopMovers();
+    expect(store.topGainers).toEqual(gainers);
+    expect(store.topLosers).toEqual(losers);
+    expect(getTopMovers).toHaveBeenCalled();
+  });
+
+  it('handles null movers result', async () => {
+    const getTopMovers = vi.fn().mockResolvedValue(null);
+    const store = createAppStore({
+      quoteService: { getTopMovers } as any,
+      newsService: { getNews: vi.fn() } as any,
+      fxService: { getRate: vi.fn() } as any,
+      trie: { search: vi.fn().mockReturnValue([]) } as any,
+    })();
+    await store.loadTopMovers();
+    expect(store.topGainers).toEqual([]);
+    expect(store.topLosers).toEqual([]);
+  });
 });


### PR DESCRIPTION
## Summary
- add getTopMovers to Marketstack service
- extend appStore with loadTopMovers and related state
- render top movers on NewsPricesPage
- cover new functionality with unit tests
- update page tests for new lists

## Testing
- `npm run lint`
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_6845be6a0c108325a21fb72444b6677d