### PR TITLE
Add headline loading to mobile app

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -1,3 +1,9 @@
+## 2025-06-08 PR #76
+- **Summary**: load headline from MarketstackService in AppStateNotifier; MainScreen displays quote with tests.
+- **Stage**: In progress
+- **Requirements addressed**: VM-01
+- **Deviations/Decisions**: Added simple Quote model in mobile app.
+- **Next step**: use news data on NewsScreen.
 
 ## 2025-06-08 PR #75
 - **Summary**: add fetchJson helper and refactor services; added tests

--- a/mobile-app/lib/models/quote.dart
+++ b/mobile-app/lib/models/quote.dart
@@ -1,0 +1,7 @@
+/// Simple quote model used by the app state.
+class Quote {
+  final String symbol;
+  final double price;
+
+  const Quote({required this.symbol, required this.price});
+}

--- a/mobile-app/lib/screens/auth/auth_screen.dart
+++ b/mobile-app/lib/screens/auth/auth_screen.dart
@@ -8,9 +8,9 @@ class AuthScreen extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final count = ref.watch(appStateProvider);
+    final state = ref.watch(appStateProvider);
     return Scaffold(
-      body: Center(child: Text('Auth Screen: $count')),
+      body: Center(child: Text('Auth Screen: ${state.count}')),
       floatingActionButton: FloatingActionButton(
         onPressed: () => ref.read(appStateProvider.notifier).increment(),
         child: const Icon(Icons.add),

--- a/mobile-app/lib/screens/detail/detail_screen.dart
+++ b/mobile-app/lib/screens/detail/detail_screen.dart
@@ -8,9 +8,9 @@ class DetailScreen extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final count = ref.watch(appStateProvider);
+    final state = ref.watch(appStateProvider);
     return Scaffold(
-      body: Center(child: Text('Detail Screen: $count')),
+      body: Center(child: Text('Detail Screen: ${state.count}')),
       floatingActionButton: FloatingActionButton(
         onPressed: () => ref.read(appStateProvider.notifier).increment(),
         child: const Icon(Icons.add),

--- a/mobile-app/lib/screens/main/main_screen.dart
+++ b/mobile-app/lib/screens/main/main_screen.dart
@@ -3,14 +3,30 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../state/app_state.dart';
 
 /// Landing page of the app showing market data.
-class MainScreen extends ConsumerWidget {
+class MainScreen extends ConsumerStatefulWidget {
   const MainScreen({super.key});
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final count = ref.watch(appStateProvider);
+  ConsumerState<MainScreen> createState() => _MainScreenState();
+}
+
+class _MainScreenState extends ConsumerState<MainScreen> {
+  @override
+  void initState() {
+    super.initState();
+    ref.read(appStateProvider.notifier).loadHeadline();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final state = ref.watch(appStateProvider);
+    final quote = state.headline;
     return Scaffold(
-      body: Center(child: Text('Main Screen: $count')),
+      body: Center(
+        child: quote != null
+            ? Text('${quote.symbol}: ${quote.price}')
+            : const Text('Loading...'),
+      ),
       floatingActionButton: FloatingActionButton(
         onPressed: () => ref.read(appStateProvider.notifier).increment(),
         child: const Icon(Icons.add),

--- a/mobile-app/lib/screens/news/news_screen.dart
+++ b/mobile-app/lib/screens/news/news_screen.dart
@@ -8,9 +8,9 @@ class NewsScreen extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final count = ref.watch(appStateProvider);
+    final state = ref.watch(appStateProvider);
     return Scaffold(
-      body: Center(child: Text('News Screen: $count')),
+      body: Center(child: Text('News Screen: ${state.count}')),
       floatingActionButton: FloatingActionButton(
         onPressed: () => ref.read(appStateProvider.notifier).increment(),
         child: const Icon(Icons.add),

--- a/mobile-app/lib/screens/portfolio/portfolio_screen.dart
+++ b/mobile-app/lib/screens/portfolio/portfolio_screen.dart
@@ -8,9 +8,9 @@ class PortfolioScreen extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final count = ref.watch(appStateProvider);
+    final state = ref.watch(appStateProvider);
     return Scaffold(
-      body: Center(child: Text('Portfolio Screen: $count')),
+      body: Center(child: Text('Portfolio Screen: ${state.count}')),
       floatingActionButton: FloatingActionButton(
         onPressed: () => ref.read(appStateProvider.notifier).increment(),
         child: const Icon(Icons.add),

--- a/mobile-app/lib/screens/pro/pro_screen.dart
+++ b/mobile-app/lib/screens/pro/pro_screen.dart
@@ -8,9 +8,9 @@ class ProScreen extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final count = ref.watch(appStateProvider);
+    final state = ref.watch(appStateProvider);
     return Scaffold(
-      body: Center(child: Text('Pro Screen: $count')),
+      body: Center(child: Text('Pro Screen: ${state.count}')),
       floatingActionButton: FloatingActionButton(
         onPressed: () => ref.read(appStateProvider.notifier).increment(),
         child: const Icon(Icons.add),

--- a/mobile-app/test/main_screen_test.dart
+++ b/mobile-app/test/main_screen_test.dart
@@ -2,34 +2,56 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mobile_app/screens/main/main_screen.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:mobile_app/state/app_state.dart';
+import 'package:smwa_services/services.dart';
+
+class _FakeMarketstackService extends MarketstackService {
+  @override
+  Future<Map<String, dynamic>> getIndexQuote(String symbol) async {
+    return {'symbol': symbol, 'price': 1.5};
+  }
+}
+
+class _NullMarketstackService extends MarketstackService {
+  @override
+  Future<Map<String, dynamic>> getIndexQuote(String symbol) async {
+    return {};
+  }
+}
+
+class _FakeNewsService extends NewsService {
+  @override
+  Future<List<Map<String, dynamic>>> getDigest(String topic) async {
+    return [];
+  }
+}
 
 void main() {
   group('MainScreen', () {
-    testWidgets('shows expected text', (tester) async {
+    testWidgets('shows quote when service returns data', (tester) async {
+      final notifier = AppStateNotifier(
+          marketstack: _FakeMarketstackService(), news: _FakeNewsService());
       await tester.pumpWidget(
-          const ProviderScope(child: MaterialApp(home: MainScreen())));
-      expect(find.text('Main Screen: 0'), findsOneWidget);
-    });
-
-    testWidgets('does not show wrong text', (tester) async {
-      await tester.pumpWidget(
-          const ProviderScope(child: MaterialApp(home: MainScreen())));
-      expect(find.text('Wrong'), findsNothing);
-    });
-
-    testWidgets('increment button increases count', (tester) async {
-      await tester.pumpWidget(
-          const ProviderScope(child: MaterialApp(home: MainScreen())));
-      await tester.tap(find.byType(FloatingActionButton));
+        ProviderScope(
+          overrides: [appStateProvider.overrideWith((ref) => notifier)],
+          child: const MaterialApp(home: MainScreen()),
+        ),
+      );
       await tester.pump();
-      expect(find.text('Main Screen: 1'), findsOneWidget);
+      expect(find.text('AAPL: 1.5'), findsOneWidget);
     });
 
-    testWidgets('negative case – count not incremented without tap',
-        (tester) async {
+    testWidgets('shows loading when service returns null', (tester) async {
+      final notifier = AppStateNotifier(
+          marketstack: _NullMarketstackService(), news: _FakeNewsService());
       await tester.pumpWidget(
-          const ProviderScope(child: MaterialApp(home: MainScreen())));
-      expect(find.text('Main Screen: 1'), findsNothing);
+        ProviderScope(
+          overrides: [appStateProvider.overrideWith((ref) => notifier)],
+          child: const MaterialApp(home: MainScreen()),
+        ),
+      );
+      await tester.pump();
+      expect(find.text('Loading...'), findsOneWidget);
     });
   });
 }


### PR DESCRIPTION
## Summary
- inject MarketstackService and NewsService
- store Quote and news in AppStateNotifier
- show headline on MainScreen
- test MainScreen behaviour
- document progress

## Checklist
- [x] `flutter analyze`
- [x] `flutter test`

## Notes
Warnings from `flutter analyze` about missing lint package and path dependencies remain.

------
https://chatgpt.com/codex/tasks/task_e_6845be6a28e08325b9c750a73474f38f