### PR TITLE
Implement NewsArticle model and integrate in News screen

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -1,3 +1,10 @@
+## 2025-06-08 PR #77
+- **Summary**: added NewsArticle model, updated AppState, NewsScreen lists articles with tests.
+- **Stage**: In progress
+- **Requirements addressed**: FR-0104, SD-03
+- **Deviations/Decisions**: none
+- **Next step**: enhance services to parse real API data
+
 ## 2025-06-08 PR #76
 - **Summary**: load headline from MarketstackService in AppStateNotifier; MainScreen displays quote with tests.
 - **Stage**: In progress

--- a/mobile-app/lib/models/news_article.dart
+++ b/mobile-app/lib/models/news_article.dart
@@ -1,0 +1,30 @@
+/// SD-03 – Lightweight news DTO used across the app.
+class NewsArticle {
+  final String title;
+  final String url;
+  final String source;
+  final DateTime published;
+
+  const NewsArticle({
+    required this.title,
+    required this.url,
+    required this.source,
+    required this.published,
+  });
+
+  factory NewsArticle.fromMap(Map<String, dynamic> map) {
+    return NewsArticle(
+      title: map['title'] as String,
+      url: map['url'] as String,
+      source: map['source'] as String? ?? '',
+      published: DateTime.parse(map['published'] as String),
+    );
+  }
+
+  Map<String, dynamic> toMap() => {
+        'title': title,
+        'url': url,
+        'source': source,
+        'published': published.toIso8601String(),
+      };
+}

--- a/mobile-app/lib/screens/news/news_screen.dart
+++ b/mobile-app/lib/screens/news/news_screen.dart
@@ -9,8 +9,20 @@ class NewsScreen extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final state = ref.watch(appStateProvider);
+    final articles = state.articles;
     return Scaffold(
-      body: Center(child: Text('News Screen: ${state.count}')),
+      body: articles != null && articles.isNotEmpty
+          ? ListView.builder(
+              itemCount: articles.length,
+              itemBuilder: (context, index) {
+                final a = articles[index];
+                return ListTile(
+                  title: Text(a.title),
+                  subtitle: Text(a.url),
+                );
+              },
+            )
+          : const Center(child: Text('No articles')),
       floatingActionButton: FloatingActionButton(
         onPressed: () => ref.read(appStateProvider.notifier).increment(),
         child: const Icon(Icons.add),

--- a/mobile-app/lib/state/app_state.dart
+++ b/mobile-app/lib/state/app_state.dart
@@ -1,17 +1,18 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:smwa_services/services.dart';
 import '../models/quote.dart';
+import '../models/news_article.dart';
 
 /// Simple state container used by the app.
 class AppState {
   final int count;
   final Quote? headline;
-  final List<Map<String, dynamic>>? articles;
+  final List<NewsArticle>? articles;
 
   const AppState({this.count = 0, this.headline, this.articles});
 
   AppState copyWith(
-      {int? count, Quote? headline, List<Map<String, dynamic>>? articles}) {
+      {int? count, Quote? headline, List<NewsArticle>? articles}) {
     return AppState(
       count: count ?? this.count,
       headline: headline ?? this.headline,
@@ -46,8 +47,9 @@ class AppStateNotifier extends StateNotifier<AppState> {
           symbol: data['symbol'] as String,
           price: (data['price'] as num).toDouble());
     }
-    final news = q != null ? await _news.getDigest(symbol) : null;
-    state = state.copyWith(headline: q, articles: news);
+    final rawNews = q != null ? await _news.getDigest(symbol) : null;
+    final articles = rawNews?.map((e) => NewsArticle.fromMap(e)).toList();
+    state = state.copyWith(headline: q, articles: articles);
   }
 }
 

--- a/mobile-app/test/news_screen_test.dart
+++ b/mobile-app/test/news_screen_test.dart
@@ -2,19 +2,40 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mobile_app/screens/news/news_screen.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:mobile_app/state/app_state.dart';
+import 'package:mobile_app/models/news_article.dart';
 
 void main() {
   group('NewsScreen', () {
-    testWidgets('shows expected text', (tester) async {
+    testWidgets('displays article titles and urls', (tester) async {
+      final notifier = AppStateNotifier();
+      notifier.state = AppState(articles: [
+        NewsArticle(
+            title: 't1',
+            url: 'u1',
+            source: 's',
+            published: DateTime.parse('2024-01-01T00:00:00Z'))
+      ]);
       await tester.pumpWidget(
-          const ProviderScope(child: MaterialApp(home: NewsScreen())));
-      expect(find.text('News Screen: 0'), findsOneWidget);
+        ProviderScope(
+          overrides: [appStateProvider.overrideWith((ref) => notifier)],
+          child: const MaterialApp(home: NewsScreen()),
+        ),
+      );
+      expect(find.text('t1'), findsOneWidget);
+      expect(find.text('u1'), findsOneWidget);
     });
 
-    testWidgets('does not show wrong text', (tester) async {
+    testWidgets('shows placeholder when no articles', (tester) async {
+      final notifier = AppStateNotifier();
+      notifier.state = const AppState(articles: []);
       await tester.pumpWidget(
-          const ProviderScope(child: MaterialApp(home: NewsScreen())));
-      expect(find.text('Wrong'), findsNothing);
+        ProviderScope(
+          overrides: [appStateProvider.overrideWith((ref) => notifier)],
+          child: const MaterialApp(home: NewsScreen()),
+        ),
+      );
+      expect(find.text('No articles'), findsOneWidget);
     });
   });
 }


### PR DESCRIPTION
## Summary
- add `NewsArticle` model for news items
- replace article maps in `AppState` with `NewsArticle` objects
- display article list on `NewsScreen`
- test article rendering and empty case

## Checklist
- [x] `dart format`
- [x] `flutter analyze lib test`
- [x] `flutter test`

## Notes
No TODO items completed.

------
https://chatgpt.com/codex/tasks/task_e_6846c0f9fbf083258bb8992abebee12d