### PR TITLE
Implement cached QuoteRepository for mobile

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -1,3 +1,10 @@
+## 2025-06-09 PR #79
+- **Summary**: added QuoteRepository with 24h caching and hooked AppStateNotifier to it; added unit tests.
+- **Stage**: In progress
+- **Requirements addressed**: FR-0101, FR-0102, FR-0103
+- **Deviations/Decisions**: flutter analyze fails due to missing generated packages
+- **Next step**: implement remaining repositories
+
 
 ## 2025-06-09 PR #78
 - **Summary**: implemented Dart fetchJson helper and refactored services; added network tests.

--- a/TODO.md
+++ b/TODO.md
@@ -9,6 +9,7 @@
 - [x] Add JSON schema models with tests in shared-contracts.
 - [x] Generate design tokens via style-dictionary for CSS and Dart.
 - [x] Build Dart service package `smwa_services` using LruCache and ApiQuotaLedger.
+- [x] Implement QuoteRepository
 - [ ] Build TypeScript package `smwa-js-services` mirroring the Dart services.
 - [ ] Create Flutter screens wired to a Riverpod `AppStateNotifier`.
 - [ ] Create PWA pages and hook them to a Pinia store.

--- a/mobile-app/lib/repositories/quote_repository.dart
+++ b/mobile-app/lib/repositories/quote_repository.dart
@@ -1,0 +1,43 @@
+import 'package:smwa_services/services.dart';
+import '../models/quote.dart';
+import 'package:smwa_services/src/lru_cache.dart';
+
+/// R-01 – Provides cached access to quotes via [MarketstackService].
+class QuoteRepository {
+  final MarketstackService _svc;
+  final LruCache<String, Quote> _headlineCache = LruCache(32);
+  final LruCache<String, List<Quote>> _seriesCache = LruCache(32);
+
+  QuoteRepository({MarketstackService? service})
+      : _svc = service ?? MarketstackService();
+
+  /// Returns the latest quote for [symbol] using a 24h cache.
+  Future<Quote?> headline([String symbol = 'AAPL']) async {
+    final cached = _headlineCache.get(symbol);
+    if (cached != null) return cached;
+    final data = await _svc.getIndexQuote(symbol);
+    if (data == null || data.isEmpty) return null;
+    final quote = Quote(
+      symbol: data['symbol'] as String,
+      price: (data['price'] as num).toDouble(),
+    );
+    _headlineCache.put(symbol, quote, const Duration(hours: 24));
+    return quote;
+  }
+
+  /// Returns a short price series for [symbol] using a 24h cache.
+  Future<List<Quote>?> series(String symbol) async {
+    final cached = _seriesCache.get(symbol);
+    if (cached != null) return cached;
+    final data = await _svc.getSeries(symbol);
+    if (data == null) return null;
+    final list = data
+        .map((e) => Quote(
+              symbol: e['symbol'] as String,
+              price: (e['close'] as num).toDouble(),
+            ))
+        .toList();
+    _seriesCache.put(symbol, list, const Duration(hours: 24));
+    return list;
+  }
+}

--- a/mobile-app/lib/state/app_state.dart
+++ b/mobile-app/lib/state/app_state.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:smwa_services/services.dart';
+import '../repositories/quote_repository.dart';
 import '../models/quote.dart';
 import '../models/news_article.dart';
 
@@ -23,12 +24,12 @@ class AppState {
 
 /// Application level state provider managing market data.
 class AppStateNotifier extends StateNotifier<AppState> {
-  final MarketstackService _marketstack;
+  final QuoteRepository _quotes;
   final NewsService _news;
 
   /// Creates an [AppStateNotifier] with optional service overrides.
-  AppStateNotifier({MarketstackService? marketstack, NewsService? news})
-      : _marketstack = marketstack ?? MarketstackService(),
+  AppStateNotifier({QuoteRepository? quotes, NewsService? news})
+      : _quotes = quotes ?? QuoteRepository(),
         _news = news ?? NewsService(),
         super(const AppState());
 
@@ -40,13 +41,7 @@ class AppStateNotifier extends StateNotifier<AppState> {
 
   /// Loads the headline quote and related news articles.
   Future<void> loadHeadline([String symbol = 'AAPL']) async {
-    final data = await _marketstack.getIndexQuote(symbol);
-    Quote? q;
-    if (data != null && data.isNotEmpty) {
-      q = Quote(
-          symbol: data['symbol'] as String,
-          price: (data['price'] as num).toDouble());
-    }
+    final q = await _quotes.headline(symbol);
     final rawNews = q != null ? await _news.getDigest(symbol) : null;
     final articles = rawNews?.map((e) => NewsArticle.fromMap(e)).toList();
     state = state.copyWith(headline: q, articles: articles);

--- a/mobile-app/test/main_screen_test.dart
+++ b/mobile-app/test/main_screen_test.dart
@@ -4,6 +4,7 @@ import 'package:mobile_app/screens/main/main_screen.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:mobile_app/state/app_state.dart';
 import 'package:smwa_services/services.dart';
+import 'package:mobile_app/repositories/quote_repository.dart';
 
 class _FakeMarketstackService extends MarketstackService {
   @override
@@ -29,8 +30,8 @@ class _FakeNewsService extends NewsService {
 void main() {
   group('MainScreen', () {
     testWidgets('shows quote when service returns data', (tester) async {
-      final notifier = AppStateNotifier(
-          marketstack: _FakeMarketstackService(), news: _FakeNewsService());
+      final repo = QuoteRepository(service: _FakeMarketstackService());
+      final notifier = AppStateNotifier(quotes: repo, news: _FakeNewsService());
       await tester.pumpWidget(
         ProviderScope(
           overrides: [appStateProvider.overrideWith((ref) => notifier)],
@@ -42,8 +43,8 @@ void main() {
     });
 
     testWidgets('shows loading when service returns null', (tester) async {
-      final notifier = AppStateNotifier(
-          marketstack: _NullMarketstackService(), news: _FakeNewsService());
+      final repo = QuoteRepository(service: _NullMarketstackService());
+      final notifier = AppStateNotifier(quotes: repo, news: _FakeNewsService());
       await tester.pumpWidget(
         ProviderScope(
           overrides: [appStateProvider.overrideWith((ref) => notifier)],

--- a/mobile-app/test/quote_repository_test.dart
+++ b/mobile-app/test/quote_repository_test.dart
@@ -1,0 +1,92 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobile_app/models/quote.dart';
+import 'package:mobile_app/repositories/quote_repository.dart';
+import 'package:smwa_services/services.dart';
+
+class _FakeMarketstackService extends MarketstackService {
+  int calls = 0;
+  Map<String, dynamic>? response;
+  List<Map<String, dynamic>>? seriesResponse;
+
+  _FakeMarketstackService({this.response, this.seriesResponse});
+
+  @override
+  Future<Map<String, dynamic>?> getIndexQuote(String symbol) async {
+    calls++;
+    return response;
+  }
+
+  @override
+  Future<List<Map<String, dynamic>>?> getSeries(String symbol) async {
+    calls++;
+    return seriesResponse;
+  }
+}
+
+void main() {
+  group('QuoteRepository.headline', () {
+    test('returns Quote on success', () async {
+      final svc = _FakeMarketstackService(response: {
+        'symbol': 'AAPL',
+        'price': 2.5,
+      });
+      final repo = QuoteRepository(service: svc);
+      final q = await repo.headline('AAPL');
+      expect(q, isA<Quote>());
+      expect(q?.symbol, 'AAPL');
+      expect(q?.price, 2.5);
+      expect(svc.calls, 1);
+    });
+
+    test('uses cache on repeated call', () async {
+      final svc = _FakeMarketstackService(response: {
+        'symbol': 'AAPL',
+        'price': 2.5,
+      });
+      final repo = QuoteRepository(service: svc);
+      final first = await repo.headline('AAPL');
+      final second = await repo.headline('AAPL');
+      expect(first, same(second));
+      expect(svc.calls, 1);
+    });
+
+    test('returns null on failure', () async {
+      final svc = _FakeMarketstackService(response: null);
+      final repo = QuoteRepository(service: svc);
+      final q = await repo.headline('AAPL');
+      expect(q, isNull);
+    });
+  });
+
+  group('QuoteRepository.series', () {
+    test('returns list of quotes', () async {
+      final svc = _FakeMarketstackService(seriesResponse: [
+        {'symbol': 'AAPL', 'close': 1.0},
+        {'symbol': 'AAPL', 'close': 2.0}
+      ]);
+      final repo = QuoteRepository(service: svc);
+      final list = await repo.series('AAPL');
+      expect(list?.length, 2);
+      expect(list?.first.price, 1.0);
+      expect(svc.calls, 1);
+    });
+
+    test('uses cache for series', () async {
+      final svc = _FakeMarketstackService(seriesResponse: [
+        {'symbol': 'AAPL', 'close': 1.0},
+      ]);
+      final repo = QuoteRepository(service: svc);
+      final first = await repo.series('AAPL');
+      final second = await repo.series('AAPL');
+      expect(first, same(second));
+      expect(svc.calls, 1);
+    });
+
+    test('returns null on series failure', () async {
+      final svc = _FakeMarketstackService(seriesResponse: null);
+      final repo = QuoteRepository(service: svc);
+      final list = await repo.series('AAPL');
+      expect(list, isNull);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- add new QuoteRepository using MarketstackService with LruCache
- wire AppStateNotifier to use QuoteRepository
- add unit tests for repository behavior
- update widget test to use repository
- document progress and mark TODO

## Testing
- `dart format mobile-app/lib/repositories/quote_repository.dart mobile-app/lib/state/app_state.dart mobile-app/test/quote_repository_test.dart mobile-app/test/main_screen_test.dart`
- `flutter analyze mobile-app` *(fails: missing generated packages)*
- `flutter test`

------
https://chatgpt.com/codex/tasks/task_e_6846cdb31b108325b7ef376d51de1331