### PR TITLE
Implement QuoteRepository and update store

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -1,3 +1,19 @@
+## 2025-06-09 PR #85
+- **Summary**: implemented QuoteRepository in the web app and refactored appStore to use it; added repository tests.
+- **Stage**: In progress
+- **Requirements addressed**: FR-0101, FR-0103
+- **Deviations/Decisions**: TypeScript repository omits series method because the service lacks it.
+- **Next step**: extend repositories for other domains.
+<details><summary>Cmd</summary>
+
+```bash
+# eslint and tests
+npm run lint
+npm test
+```
+
+</details>
+
 ## 2025-06-09 PR #79
 - **Summary**: added QuoteRepository with 24h caching and hooked AppStateNotifier to it; added unit tests.
 - **Stage**: In progress

--- a/TODO.md
+++ b/TODO.md
@@ -9,7 +9,7 @@
 - [x] Add JSON schema models with tests in shared-contracts.
 - [x] Generate design tokens via style-dictionary for CSS and Dart.
 - [x] Build Dart service package `smwa_services` using LruCache and ApiQuotaLedger.
-- [x] Implement QuoteRepository
+- [x] Implement QuoteRepository (mobile & web)
 - [ ] Build TypeScript package `smwa-js-services` mirroring the Dart services.
 - [ ] Create Flutter screens wired to a Riverpod `AppStateNotifier`.
 - [ ] Create PWA pages and hook them to a Pinia store.

--- a/web-app/src/repositories/QuoteRepository.ts
+++ b/web-app/src/repositories/QuoteRepository.ts
@@ -1,0 +1,40 @@
+import { MarketstackService, type Quote } from '@/services/MarketstackService';
+import { LruCache } from '@/utils/LruCache';
+import { DAY_MS } from '../../../packages/core/net';
+
+/**
+ * Repository providing cached access to quotes via MarketstackService.
+ */
+export class QuoteRepository {
+  private svc: MarketstackService;
+  private headlineCache = new LruCache<string, Quote>(32);
+  private moversCache = new LruCache<string, { gainers: Quote[]; losers: Quote[] }>(1);
+
+  constructor(service?: MarketstackService) {
+    this.svc =
+      service ??
+      new MarketstackService(import.meta.env.VITE_MARKETSTACK_KEY ?? '');
+  }
+
+  /**
+   * Returns the latest quote for `symbol` using a 24 h cache.
+   */
+  async headline(symbol: string = 'AAPL'): Promise<Quote | null> {
+    const cached = this.headlineCache.get(symbol);
+    if (cached) return cached;
+    const quote = await this.svc.getQuote(symbol);
+    if (quote) this.headlineCache.put(symbol, quote, DAY_MS);
+    return quote;
+  }
+
+  /**
+   * Returns the top market gainers and losers using a 24 h cache.
+   */
+  async topMovers(): Promise<{ gainers: Quote[]; losers: Quote[] } | null> {
+    const cached = this.moversCache.get('movers');
+    if (cached) return cached;
+    const data = await this.svc.getTopMovers();
+    if (data) this.moversCache.put('movers', data, DAY_MS);
+    return data;
+  }
+}

--- a/web-app/src/stores/appStore.ts
+++ b/web-app/src/stores/appStore.ts
@@ -1,5 +1,6 @@
 import { defineStore } from 'pinia';
 import { MarketstackService, type Quote } from '@/services/MarketstackService';
+import { QuoteRepository } from '@/repositories/QuoteRepository';
 import { NewsService, type NewsArticle } from '@/services/NewsService';
 import { FxService } from '@/services/FxService';
 import { SymbolTrie } from '@/utils/SymbolTrie';
@@ -15,7 +16,7 @@ export interface AppState {
 }
 
 export interface AppDeps {
-  quoteService?: MarketstackService;
+  quoteRepo?: QuoteRepository;
   newsService?: NewsService;
   fxService?: FxService;
   trie?: SymbolTrie;
@@ -34,20 +35,24 @@ export function createAppStore(deps: AppDeps = {}) {
     }),
     actions: {
       async loadHeadline(symbol: string = 'AAPL') {
-        const quoteSvc =
-          deps.quoteService ??
-          new MarketstackService(import.meta.env.VITE_MARKETSTACK_KEY ?? '');
+        const repo =
+          deps.quoteRepo ??
+          new QuoteRepository(
+            new MarketstackService(import.meta.env.VITE_MARKETSTACK_KEY ?? '')
+          );
         const newsSvc =
           deps.newsService ??
           new NewsService(import.meta.env.VITE_NEWSDATA_KEY ?? '');
-        this.headline = await quoteSvc.getQuote(symbol);
+        this.headline = await repo.headline(symbol);
         this.articles = this.headline ? await newsSvc.getNews(symbol) : null;
       },
       async loadTopMovers() {
-        const quoteSvc =
-          deps.quoteService ??
-          new MarketstackService(import.meta.env.VITE_MARKETSTACK_KEY ?? '');
-        const res = await quoteSvc.getTopMovers();
+        const repo =
+          deps.quoteRepo ??
+          new QuoteRepository(
+            new MarketstackService(import.meta.env.VITE_MARKETSTACK_KEY ?? '')
+          );
+        const res = await repo.topMovers();
         this.topGainers = res?.gainers ?? [];
         this.topLosers = res?.losers ?? [];
       },

--- a/web-app/tests/appStore.test.ts
+++ b/web-app/tests/appStore.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { createPinia, setActivePinia } from 'pinia';
 import { createAppStore } from '../src/stores/appStore';
+import { QuoteRepository } from '../src/repositories/QuoteRepository';
 import type { Quote } from '../src/services/MarketstackService';
 import type { NewsArticle } from '../src/services/NewsService';
 
@@ -14,8 +15,9 @@ describe('appStore', () => {
     const article: NewsArticle = { title: 't', url: 'u', source: 's', published: 'p' } as any;
     const getQuote = vi.fn().mockResolvedValue(quote);
     const getNews = vi.fn().mockResolvedValue([article]);
+    const repo = new QuoteRepository({ getQuote } as any);
     const store = createAppStore({
-      quoteService: { getQuote } as any,
+      quoteRepo: repo,
       newsService: { getNews } as any,
       fxService: { getRate: vi.fn() } as any,
       trie: { search: vi.fn().mockReturnValue([]) } as any
@@ -32,7 +34,7 @@ describe('appStore', () => {
     const getRate = vi.fn().mockResolvedValue(0.9);
     const store = createAppStore({
       fxService: { getRate } as any,
-      quoteService: { getQuote: vi.fn() } as any,
+      quoteRepo: new QuoteRepository({ getQuote: vi.fn() } as any),
       newsService: { getNews: vi.fn() } as any,
       trie: { search: vi.fn().mockReturnValue([]) } as any
     })();
@@ -45,7 +47,7 @@ describe('appStore', () => {
     const getRate = vi.fn().mockResolvedValue(null);
     const store = createAppStore({
       fxService: { getRate } as any,
-      quoteService: { getQuote: vi.fn() } as any,
+      quoteRepo: new QuoteRepository({ getQuote: vi.fn() } as any),
       newsService: { getNews: vi.fn() } as any,
       trie: { search: vi.fn().mockReturnValue([]) } as any
     })();
@@ -57,7 +59,7 @@ describe('appStore', () => {
     const search = vi.fn().mockReturnValue(['AAPL']);
     const store = createAppStore({
       trie: { search } as any,
-      quoteService: { getQuote: vi.fn() } as any,
+      quoteRepo: new QuoteRepository({ getQuote: vi.fn() } as any),
       newsService: { getNews: vi.fn() } as any,
       fxService: { getRate: vi.fn() } as any
     })();
@@ -69,7 +71,7 @@ describe('appStore', () => {
 
   it('signIn and upgradePro set pro flag', () => {
     const store = createAppStore({
-      quoteService: { getQuote: vi.fn() } as any,
+      quoteRepo: new QuoteRepository({ getQuote: vi.fn() } as any),
       newsService: { getNews: vi.fn() } as any,
       fxService: { getRate: vi.fn() } as any,
       trie: { search: vi.fn().mockReturnValue([]) } as any
@@ -90,7 +92,7 @@ describe('appStore', () => {
     ];
     const getTopMovers = vi.fn().mockResolvedValue({ gainers, losers });
     const store = createAppStore({
-      quoteService: { getTopMovers } as any,
+      quoteRepo: new QuoteRepository({ getTopMovers } as any),
       newsService: { getNews: vi.fn() } as any,
       fxService: { getRate: vi.fn() } as any,
       trie: { search: vi.fn().mockReturnValue([]) } as any,
@@ -104,7 +106,7 @@ describe('appStore', () => {
   it('handles null movers result', async () => {
     const getTopMovers = vi.fn().mockResolvedValue(null);
     const store = createAppStore({
-      quoteService: { getTopMovers } as any,
+      quoteRepo: new QuoteRepository({ getTopMovers } as any),
       newsService: { getNews: vi.fn() } as any,
       fxService: { getRate: vi.fn() } as any,
       trie: { search: vi.fn().mockReturnValue([]) } as any,

--- a/web-app/tests/quoteRepository.test.ts
+++ b/web-app/tests/quoteRepository.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi } from 'vitest';
+import { QuoteRepository } from '../src/repositories/QuoteRepository';
+import type { Quote } from '../src/services/MarketstackService';
+
+const sampleQuote: Quote = {
+  symbol: 'AAPL',
+  price: 1,
+  open: 1,
+  high: 1,
+  low: 1,
+  close: 1
+};
+
+const movers = { gainers: [sampleQuote], losers: [sampleQuote] };
+
+describe('QuoteRepository', () => {
+  it('caches headline results', async () => {
+    const getQuote = vi.fn().mockResolvedValue(sampleQuote);
+    const repo = new QuoteRepository({ getQuote } as any);
+    const first = await repo.headline('AAPL');
+    const second = await repo.headline('AAPL');
+    expect(first).toEqual(sampleQuote);
+    expect(second).toBe(first);
+    expect(getQuote).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns null when service fails', async () => {
+    const getQuote = vi.fn().mockResolvedValue(null);
+    const repo = new QuoteRepository({ getQuote } as any);
+    const res = await repo.headline('AAPL');
+    expect(res).toBeNull();
+  });
+
+  it('caches top movers', async () => {
+    const getTopMovers = vi.fn().mockResolvedValue(movers);
+    const repo = new QuoteRepository({ getTopMovers } as any);
+    const first = await repo.topMovers();
+    const second = await repo.topMovers();
+    expect(first).toEqual(movers);
+    expect(second).toBe(first);
+    expect(getTopMovers).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns null when movers fail', async () => {
+    const getTopMovers = vi.fn().mockResolvedValue(null);
+    const repo = new QuoteRepository({ getTopMovers } as any);
+    const res = await repo.topMovers();
+    expect(res).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- create `QuoteRepository` for the web
- refactor `appStore` to use the repository
- add repository unit tests and update existing store tests
- document work in `NOTES.md` and adjust `TODO.md`

## Checklist
- [x] `npm run lint`
- [x] `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6846d83aaf948325b8e6f0e3e5389b1b