### PR TITLE
Add PortfolioRepository with IndexedDB

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -1,3 +1,10 @@
+## 2025-06-09 PR #86
+- **Summary**: added PortfolioRepository storing holdings via idb-keyval and new Jest-style tests matching Flutter; installed fake-indexeddb for testing.
+- **Stage**: In progress
+- **Requirements addressed**: FR-0106
+- **Deviations/Decisions**: kept Vitest instead of Jest to match existing stack.
+- **Next step**: implement refreshTotals and integrate with UI.
+
 ## 2025-06-09 PR #85
 - **Summary**: implemented QuoteRepository in the web app and refactored appStore to use it; added repository tests.
 - **Stage**: In progress

--- a/TODO.md
+++ b/TODO.md
@@ -10,6 +10,7 @@
 - [x] Generate design tokens via style-dictionary for CSS and Dart.
 - [x] Build Dart service package `smwa_services` using LruCache and ApiQuotaLedger.
 - [x] Implement QuoteRepository (mobile & web)
+- [x] Implement PortfolioRepository with IndexedDB persistence
 - [ ] Build TypeScript package `smwa-js-services` mirroring the Dart services.
 - [ ] Create Flutter screens wired to a Riverpod `AppStateNotifier`.
 - [ ] Create PWA pages and hook them to a Pinia store.

--- a/web-app/package-lock.json
+++ b/web-app/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "hasInstallScript": true,
       "dependencies": {
+        "idb-keyval": "^6.2.1",
         "pinia": "^2.1.7",
         "vue": "^3.5.13",
         "vue-router": "^4.3.0"
@@ -23,6 +24,7 @@
         "@vue/tsconfig": "^0.7.0",
         "eslint": "^8.56.0",
         "eslint-plugin-vue": "^10.1.0",
+        "fake-indexeddb": "^6.0.1",
         "jsdom": "^26.1.0",
         "typescript": "~5.8.3",
         "vite": "^6.3.5",
@@ -2745,6 +2747,16 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/fake-indexeddb": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/fake-indexeddb/-/fake-indexeddb-6.0.1.tgz",
+      "integrity": "sha512-He2AjQGHe46svIFq5+L2Nx/eHDTI1oKgoevBP+TthnjymXiKkeJQ3+ITeWey99Y5+2OaPFbI1qEsx/5RsGtWnQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -3062,6 +3074,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/idb-keyval": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/idb-keyval/-/idb-keyval-6.2.1.tgz",
+      "integrity": "sha512-8Sb3veuYCyrZL+VBt9LJfZjLUPWVvqn8tG28VqYNFCo43KHcKuq+b4EiXGeuaLAQWL2YmyDgMp2aSpH9JHsEQg==",
+      "license": "Apache-2.0"
     },
     "node_modules/ignore": {
       "version": "7.0.5",

--- a/web-app/package.json
+++ b/web-app/package.json
@@ -15,9 +15,10 @@
     "postinstall": "npm install --prefix design-tokens"
   },
   "dependencies": {
+    "idb-keyval": "^6.2.1",
+    "pinia": "^2.1.7",
     "vue": "^3.5.13",
-    "vue-router": "^4.3.0",
-    "pinia": "^2.1.7"
+    "vue-router": "^4.3.0"
   },
   "devDependencies": {
     "@types/node": "^22.15.29",
@@ -29,6 +30,7 @@
     "@vue/tsconfig": "^0.7.0",
     "eslint": "^8.56.0",
     "eslint-plugin-vue": "^10.1.0",
+    "fake-indexeddb": "^6.0.1",
     "jsdom": "^26.1.0",
     "typescript": "~5.8.3",
     "vite": "^6.3.5",

--- a/web-app/src/repositories/PortfolioRepository.ts
+++ b/web-app/src/repositories/PortfolioRepository.ts
@@ -1,0 +1,65 @@
+import { get, set } from 'idb-keyval';
+import { QuoteRepository } from './QuoteRepository';
+
+export interface PortfolioHolding {
+  id: string;
+  symbol: string;
+  quantity: number;
+  buyPrice: number;
+  added: string;
+}
+
+/**
+ * Repository for persisting portfolio holdings in IndexedDB.
+ */
+export class PortfolioRepository {
+  private storeKey = 'holdings';
+  private quoteRepo: QuoteRepository;
+
+  constructor(opts?: { quoteRepo?: QuoteRepository }) {
+    this.quoteRepo = opts?.quoteRepo ?? new QuoteRepository();
+  }
+
+  /**
+   * List all saved holdings.
+   */
+  async list(): Promise<PortfolioHolding[]> {
+    const items = await get<PortfolioHolding[]>(this.storeKey);
+    return items ?? [];
+  }
+
+  /**
+   * Add a new holding after validating fields.
+   */
+  async add(h: PortfolioHolding): Promise<void> {
+    if (!h || !h.symbol || h.quantity <= 0 || h.buyPrice <= 0) {
+      throw new Error('Invalid holding');
+    }
+    const list = await this.list();
+    await set(this.storeKey, [...list, h]);
+  }
+
+  /**
+   * Remove a holding by id.
+   */
+  async remove(id: string): Promise<void> {
+    const list = await this.list();
+    await set(
+      this.storeKey,
+      list.filter(item => item.id !== id)
+    );
+  }
+
+  /**
+   * Refresh total values using cached quotes.
+   */
+  async refreshTotals(): Promise<number> {
+    const list = await this.list();
+    let total = 0;
+    for (const h of list) {
+      const quote = await this.quoteRepo.headline(h.symbol);
+      if (quote) total += quote.close * h.quantity;
+    }
+    return total;
+  }
+}

--- a/web-app/tests/PortfolioPageMirror.test.ts
+++ b/web-app/tests/PortfolioPageMirror.test.ts
@@ -1,0 +1,17 @@
+import { mount } from '@vue/test-utils';
+import { describe, it, expect } from 'vitest';
+import PortfolioPage from '../src/pages/PortfolioPage.vue';
+import { createPinia, setActivePinia } from 'pinia';
+
+describe('PortfolioPage mirror', () => {
+  setActivePinia(createPinia());
+  it('shows expected text', () => {
+    const wrapper = mount(PortfolioPage);
+    expect(wrapper.text()).toContain('Portfolio Page');
+  });
+
+  it('does not show wrong text', () => {
+    const wrapper = mount(PortfolioPage);
+    expect(wrapper.text()).not.toContain('Wrong');
+  });
+});

--- a/web-app/tests/portfolioRepository.test.ts
+++ b/web-app/tests/portfolioRepository.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import 'fake-indexeddb/auto';
+import { set } from 'idb-keyval';
+import { PortfolioRepository, PortfolioHolding } from '../src/repositories/PortfolioRepository';
+
+const sample: PortfolioHolding = {
+  id: '1',
+  symbol: 'AAPL',
+  quantity: 2,
+  buyPrice: 100,
+  added: '2024-01-01T00:00:00Z'
+};
+
+describe('PortfolioRepository', () => {
+  beforeEach(async () => {
+    await set('holdings', []);
+  });
+
+  it('adds and lists holdings', async () => {
+    const repo = new PortfolioRepository({ quoteRepo: { headline: async () => ({ close: 1 } as any) } as any });
+    await repo.add(sample);
+    const list = await repo.list();
+    expect(list.length).toBe(1);
+    expect(list[0]).toEqual(sample);
+  });
+
+  it('removes holdings by id', async () => {
+    const repo = new PortfolioRepository({ quoteRepo: { headline: async () => ({ close: 1 } as any) } as any });
+    await repo.add(sample);
+    await repo.add({ ...sample, id: '2' });
+    await repo.remove('1');
+    const list = await repo.list();
+    expect(list.length).toBe(1);
+    expect(list[0].id).toBe('2');
+  });
+
+  it('rejects invalid holding', async () => {
+    const repo = new PortfolioRepository({ quoteRepo: { headline: async () => ({ close: 1 } as any) } as any });
+    await expect(repo.add({ ...sample, quantity: 0 })).rejects.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary
- store portfolio holdings with idb-keyval
- add Vitest tests for PortfolioRepository and PortfolioPage
- install fake-indexeddb for unit tests
- document progress in NOTES and TODO

## Major design decisions
- Used `idb-keyval` for IndexedDB access to keep code small.
- Tests remain on Vitest even though docs mention Jest because the rest of the project already uses Vitest.

## Blockers / limitations
- Flutter and Dart tools are unavailable in the environment so related checks were skipped.

## Requirements addressed
- FR-0106


------
https://chatgpt.com/codex/tasks/task_e_6846e2d9785c8325965fa4def441fd7f