### PR TITLE
feat: Flutter portfolio repository

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -1,3 +1,9 @@
+## 2025-06-09 PR #87
+- **Summary**: added Flutter PortfolioRepository using SharedPreferences with hourly cached totals and tests.
+- **Stage**: In progress
+- **Requirements addressed**: FR-0106
+- **Deviations/Decisions**: totals cached via LruCache; can't run flutter tools in container.
+- **Next step**: integrate into PortfolioScreen.
 ## 2025-06-09 PR #86
 - **Summary**: added PortfolioRepository storing holdings via idb-keyval and new Jest-style tests matching Flutter; installed fake-indexeddb for testing.
 - **Stage**: In progress

--- a/TODO.md
+++ b/TODO.md
@@ -11,6 +11,7 @@
 - [x] Build Dart service package `smwa_services` using LruCache and ApiQuotaLedger.
 - [x] Implement QuoteRepository (mobile & web)
 - [x] Implement PortfolioRepository with IndexedDB persistence
+- [x] Implement PortfolioRepository for Flutter using SharedPreferences
 - [ ] Build TypeScript package `smwa-js-services` mirroring the Dart services.
 - [ ] Create Flutter screens wired to a Riverpod `AppStateNotifier`.
 - [ ] Create PWA pages and hook them to a Pinia store.

--- a/mobile-app/lib/models/portfolio_holding.dart
+++ b/mobile-app/lib/models/portfolio_holding.dart
@@ -1,0 +1,44 @@
+/// SD-05 – Local portfolio holding model.
+class PortfolioHolding {
+  final String id;
+  final String symbol;
+  final double quantity;
+  final double buyPrice;
+  final DateTime added;
+
+  const PortfolioHolding({
+    required this.id,
+    required this.symbol,
+    required this.quantity,
+    required this.buyPrice,
+    required this.added,
+  });
+
+  factory PortfolioHolding.fromMap(Map<String, dynamic> map) {
+    return PortfolioHolding(
+      id: map['id'] as String,
+      symbol: map['symbol'] as String,
+      quantity: (map['quantity'] as num).toDouble(),
+      buyPrice: (map['buyPrice'] as num).toDouble(),
+      added: DateTime.parse(map['added'] as String),
+    );
+  }
+
+  Map<String, dynamic> toMap() => {
+        'id': id,
+        'symbol': symbol,
+        'quantity': quantity,
+        'buyPrice': buyPrice,
+        'added': added.toIso8601String(),
+      };
+
+  PortfolioHolding copyWith({String? id, String? symbol, double? quantity, double? buyPrice, DateTime? added}) {
+    return PortfolioHolding(
+      id: id ?? this.id,
+      symbol: symbol ?? this.symbol,
+      quantity: quantity ?? this.quantity,
+      buyPrice: buyPrice ?? this.buyPrice,
+      added: added ?? this.added,
+    );
+  }
+}

--- a/mobile-app/lib/repositories/portfolio_repository.dart
+++ b/mobile-app/lib/repositories/portfolio_repository.dart
@@ -1,0 +1,67 @@
+import 'dart:convert';
+import 'package:shared_preferences/shared_preferences.dart';
+import '../models/portfolio_holding.dart';
+import '../models/quote.dart';
+import 'quote_repository.dart';
+import 'package:smwa_services/src/lru_cache.dart';
+
+/// R-02 – CRUD access to portfolio holdings using SharedPreferences.
+class PortfolioRepository {
+  final String _storeKey = 'holdings';
+  final QuoteRepository _quoteRepo;
+  final LruCache<String, double> _totalCache = LruCache(1);
+
+  PortfolioRepository({QuoteRepository? quoteRepo})
+      : _quoteRepo = quoteRepo ?? QuoteRepository();
+
+  Future<SharedPreferences> get _prefs async =>
+      await SharedPreferences.getInstance();
+
+  /// Returns all saved holdings.
+  Future<List<PortfolioHolding>> list() async {
+    final prefs = await _prefs;
+    final jsonStr = prefs.getString(_storeKey);
+    if (jsonStr == null) return [];
+    final List<dynamic> data = json.decode(jsonStr);
+    return data
+        .map((e) => PortfolioHolding.fromMap(e as Map<String, dynamic>))
+        .toList();
+  }
+
+  /// Adds a holding after validating fields.
+  Future<void> add(PortfolioHolding h) async {
+    if (h.symbol.isEmpty || h.quantity <= 0 || h.buyPrice <= 0) {
+      throw ArgumentError('Invalid holding');
+    }
+    final prefs = await _prefs;
+    final items = await list();
+    items.add(h);
+    await prefs.setString(
+        _storeKey, json.encode(items.map((e) => e.toMap()).toList()));
+    _totalCache.delete('total');
+  }
+
+  /// Removes a holding by [id].
+  Future<void> remove(String id) async {
+    final prefs = await _prefs;
+    final items = await list();
+    items.removeWhere((e) => e.id == id);
+    await prefs.setString(
+        _storeKey, json.encode(items.map((e) => e.toMap()).toList()));
+    _totalCache.delete('total');
+  }
+
+  /// Recalculate total value using cached quotes with 1h cache.
+  Future<double> refreshTotals() async {
+    final cached = _totalCache.get('total');
+    if (cached != null) return cached;
+    final holdings = await list();
+    double total = 0;
+    for (final h in holdings) {
+      final Quote? q = await _quoteRepo.headline(h.symbol);
+      if (q != null) total += q.price * h.quantity;
+    }
+    _totalCache.put('total', total, const Duration(hours: 1));
+    return total;
+  }
+}

--- a/mobile-app/pubspec.yaml
+++ b/mobile-app/pubspec.yaml
@@ -12,6 +12,7 @@ dependencies:
     path: packages/services
 
   flutter_riverpod: ^2.6.1
+  shared_preferences: ^2.2.2
 
 
 dev_dependencies:

--- a/mobile-app/test/portfolio_repository_test.dart
+++ b/mobile-app/test/portfolio_repository_test.dart
@@ -1,0 +1,71 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:mobile_app/models/portfolio_holding.dart';
+import 'package:mobile_app/repositories/portfolio_repository.dart';
+import 'package:mobile_app/repositories/quote_repository.dart';
+import 'package:mobile_app/models/quote.dart';
+
+class _FakeQuoteRepo implements QuoteRepository {
+  int calls = 0;
+  final double price;
+  _FakeQuoteRepo(this.price);
+
+  @override
+  Future<Quote?> headline([String symbol = 'AAPL']) async {
+    calls++;
+    return Quote(symbol: symbol, price: price);
+  }
+
+  @override
+  Future<List<Quote>?> series(String symbol) async => [];
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  const sample = PortfolioHolding(
+    id: '1',
+    symbol: 'AAPL',
+    quantity: 2,
+    buyPrice: 100,
+    added: DateTime.utc(2024, 1, 1),
+  );
+
+  group('PortfolioRepository', () {
+    setUp(() {
+      SharedPreferences.setMockInitialValues({});
+    });
+
+    test('adds and lists holdings', () async {
+      final repo = PortfolioRepository(quoteRepo: _FakeQuoteRepo(1));
+      await repo.add(sample);
+      final list = await repo.list();
+      expect(list.length, 1);
+      expect(list.first.id, '1');
+    });
+
+    test('removes holdings by id', () async {
+      final repo = PortfolioRepository(quoteRepo: _FakeQuoteRepo(1));
+      await repo.add(sample);
+      await repo.add(sample.copyWith(id: '2'));
+      await repo.remove('1');
+      final list = await repo.list();
+      expect(list.length, 1);
+      expect(list.first.id, '2');
+    });
+
+    test('rejects invalid holding', () async {
+      final repo = PortfolioRepository(quoteRepo: _FakeQuoteRepo(1));
+      expect(() async => repo.add(sample.copyWith(quantity: 0)), throwsArgumentError);
+    });
+
+    test('refreshTotals caches result', () async {
+      final fake = _FakeQuoteRepo(2);
+      final repo = PortfolioRepository(quoteRepo: fake);
+      await repo.add(sample);
+      final first = await repo.refreshTotals();
+      final second = await repo.refreshTotals();
+      expect(first, second);
+      expect(fake.calls, 1);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- implement `PortfolioRepository` in Flutter using `SharedPreferences`
- model `PortfolioHolding`
- add repository unit tests
- document work in NOTES and TODO

## PR Decision Checklist
- Major design decisions: store holdings as JSON list in SharedPreferences, totals cached for one hour using LruCache
- Deviations: cannot run Flutter tools in container so format/analyze/test steps failed
- Blockers / limitations: Flutter SDK missing
- Requirements addressed: FR-0106


------
https://chatgpt.com/codex/tasks/task_e_6846e79acb1083259185972999427b4e