### PR TITLE
Fix portfolio repo test date const

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -1,3 +1,10 @@
+## 2025-06-09 PR #88
+- **Summary**: updated PortfolioRepository test constant to use const DateTime.utc and ran formatting and analysis commands (failed in container).
+- **Stage**: In progress
+- **Requirements addressed**: FR-0106
+- **Deviations/Decisions**: container lacks dart/flutter
+- **Next step**: fix container build scripts
+
 ## 2025-06-09 PR #87
 
 - **Summary**: marked smwa-js-services, Flutter screens and PWA pages done in TODO; noted repository work underway.

--- a/mobile-app/test/portfolio_repository_test.dart
+++ b/mobile-app/test/portfolio_repository_test.dart
@@ -27,7 +27,7 @@ void main() {
     symbol: 'AAPL',
     quantity: 2,
     buyPrice: 100,
-    added: DateTime.utc(2024, 1, 1),
+    added: const DateTime.utc(2024, 1, 1),
   );
 
   group('PortfolioRepository', () {


### PR DESCRIPTION
## Summary
- use `const DateTime.utc` in portfolio repository test
- document attempt at running flutter tools

## Checklist
- [ ] Major design decisions documented
- [ ] CI passes for Dart/Flutter tools *(fails locally; tools missing)*
- [ ] `NOTES.md` updated

------
https://chatgpt.com/codex/tasks/task_e_6846eddc13208325a98e8d542184f058