### PR TITLE
Implement GPS location service

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -1,3 +1,10 @@
+## 2025-06-16 PR #91
+- **Summary**: replaced LocationService stub with geolocator-based logic and added unit tests.
+- **Stage**: improvement
+- **Requirements addressed**: FR-0109
+- **Deviations/Decisions**: used geocoding plugin instead of offline table for country lookup.
+- **Next step**: persist CountrySetting in storage.
+
 ## 2025-06-10 PR #90
 - **Summary**: added Jest to web-app with ts-jest preset, placeholder test and updated test script.
 - **Stage**: improvement

--- a/TODO.md
+++ b/TODO.md
@@ -23,4 +23,6 @@
 - [x] Add GitHub CI and Netlify pipeline with Lighthouse checks.
 - [ ] (Optional) Add a mobile-only CI workflow.
 - [ ] Repository work underway.
+- [x] Implement GPS-based LocationService returning ISO codes.
+
 

--- a/mobile-app/packages/services/lib/src/location_service.dart
+++ b/mobile-app/packages/services/lib/src/location_service.dart
@@ -1,4 +1,20 @@
+import 'package:geolocator/geolocator.dart';
+import 'package:geocoding/geocoding.dart';
+
 import 'api_quota_ledger.dart';
+
+/// Function returning the current position. Overridden in tests.
+Future<Position> Function() positionGetter = () => Geolocator.getCurrentPosition(
+      desiredAccuracy: LocationAccuracy.medium,
+      timeLimit: const Duration(seconds: 5),
+    );
+
+/// Function mapping coordinates to an ISO 3166 code. Overridden in tests.
+Future<String?> Function(double lat, double lon) isoCodeGetter =
+    (lat, lon) async {
+  final placemarks = await placemarkFromCoordinates(lat, lon);
+  return placemarks.isEmpty ? null : placemarks.first.isoCountryCode;
+};
 
 /// S-04 – LocationService
 class LocationService {
@@ -6,7 +22,23 @@ class LocationService {
 
   Future<Map<String, dynamic>> resolveCountry() async {
     if (!_ledger.isSafe()) throw Exception('quota exceeded');
+
+    final permission = await Geolocator.checkPermission();
+    if (permission == LocationPermission.denied ||
+        permission == LocationPermission.deniedForever) {
+      final req = await Geolocator.requestPermission();
+      if (req == LocationPermission.denied ||
+          req == LocationPermission.deniedForever) {
+        throw Exception('permission denied');
+      }
+    }
+
+    final pos = await positionGetter();
+    final iso2 = await isoCodeGetter(pos.latitude, pos.longitude);
+    if (iso2 == null) throw Exception('country not found');
+
     _ledger.increment();
-    return {'iso2': 'US'};
+    return {'iso2': iso2};
   }
 }
+

--- a/mobile-app/packages/services/pubspec.yaml
+++ b/mobile-app/packages/services/pubspec.yaml
@@ -6,6 +6,8 @@ environment:
 
 dependencies:
   http: ^1.1.0
+  geolocator: ^10.1.0
+  geocoding: ^2.1.0
 
 dev_dependencies:
   test: ^1.24.0

--- a/mobile-app/packages/services/test/location_service_test.dart
+++ b/mobile-app/packages/services/test/location_service_test.dart
@@ -1,10 +1,42 @@
 import 'package:smwa_services/services.dart';
+import 'package:smwa_services/src/location_service.dart' as loc;
+import 'package:geolocator/geolocator.dart';
 import 'package:test/test.dart';
 
+Position _pos() => Position(
+      latitude: 1.0,
+      longitude: 2.0,
+      timestamp: DateTime.now(),
+      accuracy: 0,
+      altitude: 0,
+      heading: 0,
+      headingAccuracy: 0,
+      speed: 0,
+      speedAccuracy: 0,
+    );
+
 void main() {
-  test('resolveCountry returns stub', () async {
+  tearDown(() {
+    loc.positionGetter = () => Geolocator.getCurrentPosition();
+    loc.isoCodeGetter = (lat, lon) async {
+      final placemarks = await placemarkFromCoordinates(lat, lon);
+      return placemarks.isEmpty ? null : placemarks.first.isoCountryCode;
+    };
+  });
+
+  test('resolveCountry returns iso code', () async {
+    loc.positionGetter = () async => _pos();
+    loc.isoCodeGetter = (lat, lon) async => 'GB';
     final svc = LocationService();
     final c = await svc.resolveCountry();
-    expect(c['iso2'], 'US');
+    expect(c['iso2'], 'GB');
+  });
+
+  test('resolveCountry throws when iso not found', () async {
+    loc.positionGetter = () async => _pos();
+    loc.isoCodeGetter = (lat, lon) async => null;
+    final svc = LocationService();
+    expect(() async => await svc.resolveCountry(), throwsException);
   });
 }
+


### PR DESCRIPTION
## Summary
- implement LocationService with geolocator and geocoding
- test positive and negative cases with stubs
- add geolocator/geocoding deps
- document progress and todo items

## PR Decision Checklist
- **Major design decisions**: LocationService now uses geolocator APIs with injectable functions for tests.
- **Deviations**: docs mention offline table for reverse geocoding; used geocoding plugin instead for simplicity.
- **Blockers**: `dart` and `flutter` commands unavailable so format, analyze and Flutter tests failed locally.
- **Requirements addressed**: FR-0109

------
https://chatgpt.com/codex/tasks/task_e_684fe1f6082483258d93764fd19e1889