### PR TITLE
Add shared analysis settings

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,6 +68,8 @@ calls · month⁻¹, ≤ 200 NewsData calls · day⁻¹).
 
 ## Testing & CI
 - Run `dart format`, `flutter analyze`, `flutter test`, `eslint --fix`, and `npm test` before committing.
+- `flutter analyze` at the repo root uses `analysis_options.yaml` which includes
+  `mobile-app/analysis_options.yaml` and excludes generated design tokens.
 - Run `npm install` in `web-app/` before tests so the style-dictionary build step works.
 - Provide at least one positive and one negative unit test per public API, aiming for ≥75 % branch coverage.
 - GitHub Actions in `.github/workflows/ci.yml` will build the web app, run tests, trigger a Netlify deployment and execute Lighthouse CI. Keep the pipeline green.

--- a/CODING_RULES.md
+++ b/CODING_RULES.md
@@ -22,7 +22,7 @@
 ## Environment & config
 16. Runtime config ONLY via env-vars / secrets manager – `VITE_MARKETSTACK_KEY`, `VITE_NEWSDATA_KEY`, etc.
 17. Lint-defined code style: 2-space indent, single quotes, trailing newline. The
-    lint rules live in `mobile-app/analysis_options.yaml` and are checked via
-    `flutter analyze`.
+    repo root `analysis_options.yaml` references `mobile-app/analysis_options.yaml`
+    and is used when running `flutter analyze`.
 
 *(CI enforces CVE scans, licence checks, coverage threshold, and prettier formatting – see `.github/workflows/`.)*

--- a/NOTES.md
+++ b/NOTES.md
@@ -1,3 +1,10 @@
+## 2025-06-16 PR #102
+- **Summary**: added root analysis_options.yaml; updated AGENTS and CODING_RULES.
+- **Stage**: documentation
+- **Requirements addressed**: N/A
+- **Deviations/Decisions**: root file excludes design tokens path.
+- **Next step**: verify cross-platform behaviour of NetClient.
+
 ## 2025-06-16 PR #100
 - **Summary**: implemented web CountrySettingRepository with localStorage and unit tests; updated README and TODO.
 - **Stage**: implementation

--- a/TODO.md
+++ b/TODO.md
@@ -25,6 +25,7 @@
 - [x] Implement GPS-based LocationService returning ISO codes.
 - [x] Add CountrySettingRepository for the web using localStorage.
 - [x] Implement CountrySettingRepository for web.
+- [x] Added root analysis_options.yaml for repo-level analyzer.
 
 # In progress
 - [ ] Verify cross-platform behaviour of NetClient.
@@ -49,5 +50,3 @@
 - [ ] Wire Flutter store.
 - [ ] Monitor CI runs.
 - [ ] Integrate Riverpod and Pinia state stores.
-- [x] Persist CountrySetting in storage.
-- [ ] 

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,0 +1,5 @@
+include: mobile-app/analysis_options.yaml
+
+analyzer:
+  exclude:
+    - web-app/design-tokens/**


### PR DESCRIPTION
## Summary
- create `analysis_options.yaml` to share Flutter lints
- document how `flutter analyze` uses this file
- keep coding rules and contributors guide up to date
- record changes in project notes and TODO

## Testing
- `dart format -o none -l 80 .`
- `flutter analyze` *(fails: 362 issues found)*
- `cd mobile-app && flutter test`
- `cd web-app && npm install`
- `cd web-app && npm run lint`
- `cd web-app && npm test`


------
https://chatgpt.com/codex/tasks/task_e_684ff61414d88325be49359487bab09e