### PR TITLE
Fix vue-tsc include path

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -1,4 +1,11 @@
 
+## 2025-06-19 PR #XXX
+- **Summary**: extended web tsconfig include to packages/core for vue-tsc.
+- **Stage**: implementation
+- **Requirements addressed**: N/A
+- **Deviations/Decisions**: none
+- **Next step**: monitor CI for tsconfig compile errors.
+
 ## 2025-06-18 PR #102
 - **Summary**: documented tokens build order in README and AGENTS.
 - **Stage**: documentation

--- a/TODO.md
+++ b/TODO.md
@@ -27,6 +27,7 @@
 - [x] Implement CountrySettingRepository for web.
 - [x] Document tokens build dependency before Flutter analysis.
 - [x] Added root analysis_options.yaml for repo-level analyzer.
+- [x] Include packages/core in web tsconfig to fix vue-tsc list errors.
 
 # In progress
 - [ ] Verify cross-platform behaviour of NetClient.

--- a/web-app/tsconfig.json
+++ b/web-app/tsconfig.json
@@ -4,7 +4,8 @@
     "src/**/*.ts",
     "src/**/*.d.ts",
     "src/**/*.vue",
-    "../packages/generated-ts/**/*.ts"
+    "../packages/generated-ts/**/*.ts",
+    "../packages/core/**/*.ts"
   ],
   "compilerOptions": {
     "composite": true,


### PR DESCRIPTION
## Summary
- extend web-app tsconfig to pull in core package files
- update TODO and notes

## Testing
- `dart format --output=none --set-exit-if-changed .`
- `flutter analyze` *(fails: URI hasn't been generated)*
- `flutter test` *(fails: Test directory "test" not found)*
- `npx eslint . --fix`
- `npm test`
- `npx vue-tsc -b` *(errors: TS2307 cannot find module, but no "File ... is not listed" errors)*

------
https://chatgpt.com/codex/tasks/task_e_684ffe5182888325ac59eca47146b382