### PR TITLE
Update AGENTS about tsconfig and generics

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,6 +38,9 @@ This repository hosts a cross-platform stock market app with a Flutter mobile fr
    cd web-app
    npm install && npm run dev
    ```
+4. When TypeScript files outside `web-app/src/` are imported (e.g. under
+   `packages/`), update `web-app/tsconfig.json` to include those paths.
+   Missing entries cause TS6307 build failures.
 
 Create identical `.env` files in `mobile-app/` and `web-app/` containing:
 ```
@@ -64,6 +67,8 @@ calls · month⁻¹, ≤ 200 NewsData calls · day⁻¹).
 - Document each public API/function with a doc comment.
 - Log `loadTimeMs` and external API latency in debug builds.
 - State management: Riverpod (Flutter) and Pinia (Vue) – avoid global singletons.
+- The generic parameter of `NetClient.get<T>` must match the transform function's
+  return type.
 (These frameworks are planned; current code does not yet use them.)
 
 ## Testing & CI

--- a/NOTES.md
+++ b/NOTES.md
@@ -1,3 +1,10 @@
+## 2025-06-19 PR #103
+- **Summary**: noted tsconfig path rule and NetClient.get generic usage in AGENTS.
+- **Stage**: documentation
+- **Requirements addressed**: N/A
+- **Deviations/Decisions**: emphasised TS6307 prevention and generic match.
+- **Next step**: ensure builds include package sources.
+
 
 ## 2025-06-18 PR #102
 - **Summary**: documented tokens build order in README and AGENTS.

--- a/TODO.md
+++ b/TODO.md
@@ -13,6 +13,7 @@
 - [x] Generate design tokens via style-dictionary for CSS and Dart.
 - [x] Build Dart service package `smwa_services` using LruCache and ApiQuotaLedger.
 - [x] Implement QuoteRepository (mobile & web)
+- [x] Document tsconfig path requirement when importing packages to avoid TS6307.
 - [x] Implement PortfolioRepository with IndexedDB persistence
 - [x] Build TypeScript package `smwa-js-services` mirroring the Dart services.
 - [x] Implement CredentialStore storing bcrypt hashes encrypted via AES in SharedPreferences.


### PR DESCRIPTION
## Summary
- document tsconfig path inclusion when importing packages
- note that NetClient.get generic must match its transform return type
- log the change in NOTES and TODO

## PR Decision Checklist
- **Major design decisions**: none
- **Deviations from docs**: none
- **Blockers / limitations**: none
- **Requirements addressed**: N/A

------
https://chatgpt.com/codex/tasks/task_e_684ffe5306988325bcc714225a1f1f9c