### PR TITLE
Update docs with TypeScript fixes

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -1,4 +1,11 @@
 
+## 2025-06-19 PR #107
+- **Summary**: fixed NewsService type handling and updated tsconfig to include generated models.
+- **Stage**: improvement
+- **Requirements addressed**: N/A
+- **Deviations/Decisions**: ensures typed API results and compilation against packages.
+- **Next step**: verify tsconfig paths after adding packages.
+
 ## 2025-06-18 PR #102
 - **Summary**: documented tokens build order in README and AGENTS.
 - **Stage**: documentation

--- a/TODO.md
+++ b/TODO.md
@@ -51,3 +51,4 @@
 - [ ] Wire Flutter store.
 - [ ] Monitor CI runs.
 - [ ] Integrate Riverpod and Pinia state stores.
+- [ ] Verify tsconfig paths whenever packages are added.


### PR DESCRIPTION
## Summary
- log TS fixes and tsconfig change in NOTES
- remind maintainers to verify tsconfig paths in TODO

## Testing
- `npx markdownlint README.md NOTES.md TODO.md AGENTS.md`
- `npx markdown-link-check README.md`

------
https://chatgpt.com/codex/tasks/task_e_684ffe53912883258e6071d978e4052e