### PR TITLE
Update tsconfig docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,7 +40,8 @@ This repository hosts a cross-platform stock market app with a Flutter mobile fr
    ```
 4. When TypeScript files outside `web-app/src/` are imported (e.g. under
    `packages/`), update `web-app/tsconfig.json` to include those paths.
-   Missing entries cause TS6307 build failures.
+   Missing entries cause TS6307 build failures. Exclude each package's
+   `tests/` directory to keep the build fast.
 
 Create identical `.env` files in `mobile-app/` and `web-app/` containing:
 ```

--- a/NOTES.md
+++ b/NOTES.md
@@ -1,3 +1,10 @@
+## 2025-06-20 PR #XXX
+- **Summary**: added rule to exclude package test folders when updating tsconfig.
+- **Stage**: documentation
+- **Requirements addressed**: N/A
+- **Deviations/Decisions**: none
+- **Next step**: monitor tsconfig updates in PRs.
+
 ## 2025-06-19 PR #103
 - **Summary**: noted tsconfig path rule and NetClient.get generic usage in AGENTS.
 - **Stage**: documentation

--- a/TODO.md
+++ b/TODO.md
@@ -29,6 +29,7 @@
 - [x] Document tokens build dependency before Flutter analysis.
 - [x] Added root analysis_options.yaml for repo-level analyzer.
 - [x] Include packages/core in web tsconfig to fix vue-tsc list errors.
+- [x] Exclude package tests directories when adding their sources to web tsconfig.
 
 # In progress
 - [ ] Verify cross-platform behaviour of NetClient.


### PR DESCRIPTION
## Summary
- mention excluding package `tests/` directories when extending `web-app/tsconfig.json`
- log the rule in NOTES
- tick a TODO item about it

## Testing
- `npx markdownlint-cli AGENTS.md NOTES.md TODO.md` *(fails: could not run due to env restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_685002785b248325bec578881ed94b60