### PR TITLE
docs: clarify cross-package import paths

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,6 +42,9 @@ This repository hosts a cross-platform stock market app with a Flutter mobile fr
    `packages/`), update `web-app/tsconfig.json` to include those paths and
    exclude `../packages/**/tests` so vue-tsc skips package tests.
    Missing entries cause TS6307 build failures.
+   Files inside `packages/<name>/src` are three levels deep, so imports of web
+   utilities must use `'../../../web-app/src/…'`. Files at the package root use
+   `'../../web-app/src/…'`.
 
 Create identical `.env` files in `mobile-app/` and `web-app/` containing:
 ```

--- a/NOTES.md
+++ b/NOTES.md
@@ -1,3 +1,10 @@
+## 2025-06-16 PR #XXX
+- **Summary**: document cross-package import paths in AGENTS.
+- **Stage**: documentation
+- **Requirements addressed**: N/A
+- **Deviations/Decisions**: none
+- **Next step**: verify CI docs jobs pass.
+
 ## 2025-06-19 PR #XXX
 - **Summary**: corrected core net utility import paths.
 - **Stage**: bug fix

--- a/TODO.md
+++ b/TODO.md
@@ -55,6 +55,6 @@
 - [ ] Monitor CI runs.
 - [ ] Integrate Riverpod and Pinia state stores.
 - [ ] Verify tsconfig paths whenever packages are added.
-- [ ] Add check to ensure packages reference web utilities via '../../web-app/src/utils/'.
+- [ ] Add check to ensure packages reference web utilities via '../../web-app/src/…' at the package root and '../../../web-app/src/…' inside `packages/<name>/src`.
 - [ ] Verify tsconfig excludes to ensure package tests are ignored.
 - [ ] Investigate flutter analyze errors from generated-dart serializers


### PR DESCRIPTION
## Summary
- document relative import depth for packages
- tweak TODO to mention correct paths
- log the update in NOTES

## Testing
- `npx markdownlint-cli '**/*.md' --ignore 'web-app/node_modules' --ignore 'web-app/design-tokens/node_modules' --ignore 'mobile-app/**/node_modules' --ignore 'packages/**/node_modules'`
- `npx markdown-link-check -q README.md`

------
https://chatgpt.com/codex/tasks/task_e_685007b803e08325aa8af1ae5c23e0d7