### PR TITLE
docs: add TTL usage note

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -1,3 +1,10 @@
+## 2025-06-24 PR #XXX
+- **Summary**: all Dart services now pass `ttl` to NetClient; TODO resolved.
+- **Stage**: implementation
+- **Requirements addressed**: FR-0104, LIM-0016
+- **Deviations/Decisions**: none
+- **Next step**: verify cross-platform behaviour of NetClient.
+
 ## 2025-06-23 PR #XXX
 - **Summary**: added ttl parameter to NetClient and services; NewsService now caches 12h.
 - **Stage**: implementation

--- a/TODO.md
+++ b/TODO.md
@@ -62,4 +62,4 @@
 - [ ] Add check to ensure packages reference web utilities via '../../web-app/src/…' at the package root and '../../../web-app/src/…' inside `packages/<name>/src`.
 - [ ] Verify tsconfig excludes to ensure package tests are ignored.
 - [ ] Investigate flutter analyze errors from generated-dart serializers
-- [ ] Update Flutter services to pass ttlMs to NetClient calls
+- [x] Update Flutter services to pass ttlMs to NetClient calls


### PR DESCRIPTION
## Summary
- check off TODO for Dart TTL on NetClient calls
- log that all Dart services now use the ttl parameter

## Testing
- `npx markdownlint-cli TODO.md NOTES.md` *(fails: numerous pre-existing lint errors)*
- `npx markdown-link-check NOTES.md -q`
- `npx markdown-link-check TODO.md -q`

------
https://chatgpt.com/codex/tasks/task_e_685018faa31483259bce458434164b9d