### PR TITLE
docs: add markdown link check instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,6 +86,8 @@ caching period. Free‑tier quotas remain ≤ 100 Marketstack/FX calls · month�
   `mobile-app/analysis_options.yaml` and excludes generated design tokens.
 - Run `npm install` in `web-app/` before tests so the style-dictionary build step works.
 - Run `npm run tokens` (or run tests) before any Flutter analysis or build steps so `tokens.dart` exists.
+- Run the documentation link check with Node 20:
+  `npx markdown-link-check README.md`.
 - Provide at least one positive and one negative unit test per public API, aiming for ≥75 % branch coverage.
 - GitHub Actions in `.github/workflows/ci.yml` will build the web app, run tests, trigger a Netlify deployment and execute Lighthouse CI. Keep the pipeline green.
 

--- a/NOTES.md
+++ b/NOTES.md
@@ -1,3 +1,10 @@
+## 2025-06-16 PR #XXX
+- **Summary**: added Node 20 and markdown link check instructions in docs.
+- **Stage**: documentation
+- **Requirements addressed**: N/A
+- **Deviations/Decisions**: emphasised Node 20; doc link check via npx.
+- **Next step**: add automated job for docs.
+
 ## 2025-06-24 PR #XXX
 - **Summary**: all Dart services now pass `ttl` to NetClient; TODO resolved.
 - **Stage**: implementation

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ LHCI_GITHUB_APP_TOKEN=YOUR_LHCI_TOKEN  # CI only
 
 ### Prerequisites
 Before running the apps ensure the correct toolchains are installed:
-* **Node 20** for the web app
+* **Node 20** for the web app and documentation checks
 * **Flutter 3.22** for the mobile app
 Detailed setup steps live in `AGENTS.md`.
 
@@ -125,6 +125,10 @@ Run tests from each app before pushing:
 ```bash
 cd mobile-app && flutter test
 cd ../web-app && npm test
+```
+Run the documentation checks with Node 20:
+```bash
+npx markdown-link-check README.md
 ```
 
 flutter test and npm test – keep CI green

--- a/TODO.md
+++ b/TODO.md
@@ -56,6 +56,7 @@
 - [ ] Expand to remaining service stubs.
 - [ ] Wire Flutter store.
 - [ ] Monitor CI runs.
+- [ ] Keep AGENTS.md up to date whenever CI tooling changes.
 - [ ] Integrate Riverpod and Pinia state stores.
 - [ ] Verify tsconfig paths whenever packages are added.
 - [ ] Document that `packages/<pkg>/src` must import web utilities using '../../../web-app/src/'.


### PR DESCRIPTION
## Summary
- explicitly mention Node 20 when describing prerequisites
- document how to run markdown link checks
- remind devs to update AGENTS when CI tooling changes

## Testing
- `yes | npx markdown-link-check README.md` *(fails: 2 dead links)*
- `npx markdownlint README.md AGENTS.md NOTES.md TODO.md` *(fails: could not determine executable)*

------
https://chatgpt.com/codex/tasks/task_e_68501e0647008325986a79a6c56c7397