### PR TITLE
Fix CI step for service package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,8 +41,8 @@ jobs:
         working-directory: mobile-app
       - name: Run service package tests
         run: |
-          dart pub get
-          dart test
+          flutter pub get
+          flutter test
         working-directory: mobile-app/packages/services
       - name: Run Flutter tests
         run: flutter test

--- a/.github/workflows/flutter_test.yml
+++ b/.github/workflows/flutter_test.yml
@@ -24,8 +24,8 @@ jobs:
         working-directory: mobile-app
       - name: Run service package tests
         run: |
-          dart pub get
-          dart test
+          flutter pub get
+          flutter test
         working-directory: mobile-app/packages/services
       - name: Run Flutter tests
         run: flutter test

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,6 +86,7 @@ caching period. Free‑tier quotas remain ≤ 100 Marketstack/FX calls · month�
   `mobile-app/analysis_options.yaml` and excludes generated design tokens.
 - Run `npm install` in `web-app/` before tests so the style-dictionary build step works.
 - Run `npm run tokens` (or run tests) before any Flutter analysis or build steps so `tokens.dart` exists.
+- `mobile-app/packages/services` uses Flutter plugins, so its tests must run via `flutter test` (not `dart test`).
 - Run the documentation link check with Node 20:
   `npx markdown-link-check README.md`.
 - CI runs this check via `.github/workflows/docs.yml`. Run it locally whenever you edit README or other docs files.

--- a/NOTES.md
+++ b/NOTES.md
@@ -1,3 +1,10 @@
+## 2025-06-27 PR #XXX
+- **Summary**: CI workflows now run the service package tests with `flutter test` because the package uses Flutter plugins.
+- **Stage**: implementation
+- **Requirements addressed**: N/A
+- **Deviations/Decisions**: replaced `dart test` with `flutter test` in CI for plugin compatibility.
+- **Next step**: ensure CI passes after workflow updates.
+
 ## 2025-06-26 PR #XXX
 - **Summary**: added LocationService parity tests across web and mobile and enabled service package tests in CI.
 - **Stage**: testing

--- a/TODO.md
+++ b/TODO.md
@@ -59,6 +59,7 @@
 - [ ] Wire Flutter store.
 - [ ] Monitor CI runs.
 - [ ] Keep AGENTS.md up to date whenever CI tooling changes.
+- [ ] Remember `mobile-app/packages/services` tests require `flutter test`.
 - [ ] Integrate Riverpod and Pinia state stores.
 - [ ] Verify tsconfig paths whenever packages are added.
 - [ ] Document that `packages/<pkg>/src` must import web utilities using '../../../web-app/src/'.


### PR DESCRIPTION
## Summary
- run the service package tests with `flutter test` in both CI workflows
- document that the services package needs Flutter-based tests
- note workflow change in NOTES and TODO

## Testing
- `npx -y markdown-link-check README.md` *(fails: 2 dead links)*

------
https://chatgpt.com/codex/tasks/task_e_68513adea7cc8325a8737fff07203257