### PR TITLE
Add SymbolTrie tests

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -1,3 +1,10 @@
+## 2025-06-28 PR #XXX
+- **Summary**: added SymbolTrie unit tests for basic search behavior.
+- **Stage**: testing
+- **Requirements addressed**: FR-0112
+- **Deviations/Decisions**: simple in-memory trie suffices for now.
+- **Next step**: monitor CI and expand search tests as needed.
+
 ## 2025-06-27 PR #XXX
 - **Summary**: CI workflows now run the service package tests with `flutter test` because the package uses Flutter plugins.
 - **Stage**: implementation

--- a/TODO.md
+++ b/TODO.md
@@ -52,6 +52,7 @@
 - [ ] Monitor for further API integration.
 - [ ] Use news data on NewsScreen.
 - [ ] Expand store features.
+- [ ] Implement ranking for SymbolTrie suggestions.
 - [x] Integrate helper in mobile services.
 - [ ] Flesh out real API calls.
 - [ ] Expand state usage across app.

--- a/web-app/tests/SymbolTrie.test.ts
+++ b/web-app/tests/SymbolTrie.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from 'vitest';
+import { SymbolTrie } from '../src/utils/SymbolTrie';
+
+describe('SymbolTrie', () => {
+  it('returns matches for prefixes', () => {
+    const trie = new SymbolTrie();
+    trie.load(['AAA', 'AAB']);
+    expect(trie.search('AA')).toEqual(['AAA', 'AAB']);
+  });
+
+  it('returns empty array when no symbols match', () => {
+    const trie = new SymbolTrie();
+    trie.load(['AAA', 'AAB']);
+    expect(trie.search('ZZ')).toEqual([]);
+  });
+});
+


### PR DESCRIPTION
## Summary
- test SymbolTrie prefix matches and empty results
- note SymbolTrie tests and add follow-up item for ranking suggestions

## Testing
- `npm --prefix web-app test`
- `flutter test` in `mobile-app`
- `npx markdown-link-check README.md` *(fails: 2 dead links)*

------
https://chatgpt.com/codex/tasks/task_e_68513f650b9c8325afcbea117213267f