### PR TITLE
Add auth login negative tests

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -1,3 +1,10 @@
+## 2025-06-29 PR #XXX
+- **Summary**: added negative tests for AuthService login rejecting empty inputs.
+- **Stage**: testing
+- **Requirements addressed**: N/A
+- **Deviations/Decisions**: stub login returns false when either email or password is empty.
+- **Next step**: monitor CI for cross-tool coverage.
+
 ## 2025-06-28 PR #XXX
 - **Summary**: added SymbolTrie unit tests for basic search behavior.
 - **Stage**: testing

--- a/TODO.md
+++ b/TODO.md
@@ -35,6 +35,7 @@
 - [x] Remove obsolete `web-app/packages/services` folder; services live in
   `web-app/src/services`.
 - [x] Add tests for `useLoadTimeLogger` hook.
+- [x] Add negative tests for AuthService login.
 
 # In progress
 - [x] Verify cross-platform behaviour of NetClient.

--- a/mobile-app/packages/services/test/auth_service_test.dart
+++ b/mobile-app/packages/services/test/auth_service_test.dart
@@ -13,4 +13,10 @@ void main() {
     final ok = await svc.login('a@b.com', 'pwd');
     expect(ok, isTrue);
   });
+
+  test('login fails with empty email or password', () async {
+    final svc = AuthService();
+    expect(await svc.login('', 'pwd'), isFalse);
+    expect(await svc.login('a@b.com', ''), isFalse);
+  });
 }


### PR DESCRIPTION
## Summary
- check login returns false on blank email or password
- document the new tests
- mark TODO entry completed

## Testing
- `npm run lint`
- `npm test`
- `flutter analyze` *(fails: undefined identifiers)*
- `flutter test` in `mobile-app`
- `flutter test` in `mobile-app/packages/services` *(fails: some tests fail)*

------
https://chatgpt.com/codex/tasks/task_e_685143dca68c8325a7077bd45d348fc2