### PR TITLE
Update CI docs for packages

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,6 +85,7 @@ caching period. Free‑tier quotas remain ≤ 100 Marketstack/FX calls · month�
 - `flutter analyze` at the repo root uses `analysis_options.yaml` which includes
   `mobile-app/analysis_options.yaml` and excludes generated design tokens.
 - Run `npm install` in `web-app/` before tests so the style-dictionary build step works.
+- Package tests import utilities from `web-app/src/`, so run `npm ci` in `web-app/` before executing tests in `packages/`.
 - After setting up Node, run `npm ci` and `npm test` in `packages/` to verify the
   shared client packages.
 - Run `npm run tokens` (or run tests) before any Flutter analysis or build steps so `tokens.dart` exists.

--- a/NOTES.md
+++ b/NOTES.md
@@ -1,3 +1,9 @@
+## 2025-06-17 PR #XXX
+- **Summary**: Document running `npm ci` in web-app before packages tests.
+- **Stage**: documentation
+- **Requirements addressed**: N/A
+- **Deviations/Decisions**: packages tests import web utilities
+- **Next step**: monitor docs for clarity
 
 ## 2025-06-17 PR #XXX
 - **Summary**: CI runs `npm ci` and `npm test` in packages before web build.

--- a/TODO.md
+++ b/TODO.md
@@ -62,7 +62,8 @@
 - [ ] Wire Flutter store.
 - [ ] Monitor CI runs.
 - [x] Keep AGENTS.md up to date whenever CI tooling changes.
-- [ ] Ensure packages tests run via `npm ci` and `npm test` in CI workflow.
+- [x] Ensure packages tests run via `npm ci` and `npm test` in CI workflow.
+- [x] Document that packages tests depend on web utilities; run `npm ci` in `web-app/` before `packages` tests.
 - [ ] Remember `mobile-app/packages/services` tests require `flutter test`.
 - [ ] Integrate Riverpod and Pinia state stores.
 - [ ] Verify tsconfig paths whenever packages are added.
@@ -71,3 +72,4 @@
 - [ ] Verify tsconfig excludes to ensure package tests are ignored.
 - [ ] Investigate flutter analyze errors from generated-dart serializers
 - [x] Update Flutter services to pass ttlMs to NetClient calls
+- [ ] Fix README CI badge links for markdown-link-check


### PR DESCRIPTION
## Summary
- clarify that packages tests import web utilities so npm ci must run in web-app first
- log the new guideline in NOTES
- update TODO items

## Testing
- `npm_config_yes=true npx markdown-link-check README.md` *(fails: 2 broken links)*
- `npx markdownlint-cli AGENTS.md NOTES.md TODO.md README.md` *(fails: lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_685148a24c1c8325bf04dfe6321bf972