### PR TITLE
Update doc link check instructions

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,4 +15,4 @@ jobs:
         with:
           node-version: 20
       - name: Check links
-        run: npx markdown-link-check README.md
+        run: npx -y markdown-link-check README.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,8 +91,8 @@ caching period. Free‑tier quotas remain ≤ 100 Marketstack/FX calls · month�
 - Run `npm run tokens` (or run tests) before any Flutter analysis or build steps so `tokens.dart` exists.
 - `mobile-app/packages/services` uses Flutter plugins, so its tests must run via `flutter test` (not `dart test`).
 - The shared packages under `packages/` install via `npm ci` and run `npm test` in CI.
-- Run the documentation link check with Node 20:
-  `npx markdown-link-check README.md`.
+- Run the documentation link check with Node 20 (use `-y` to skip prompts):
+  `npx -y markdown-link-check README.md`.
 - CI runs this check via `.github/workflows/docs.yml`. Run it locally whenever you edit README or other docs files.
 - Provide at least one positive and one negative unit test per public API, aiming for ≥75 % branch coverage.
 - Add parity tests under `web-app/tests/*Parity.test.ts` and
@@ -121,7 +121,7 @@ caching period. Free‑tier quotas remain ≤ 100 Marketstack/FX calls · month�
 ## Contributing Workflow
 - **Fork** then branch off `main` using the pattern `feat/<topic>`.
 - **Ensure local tests pass** before opening a PR.
-- Run `npx markdown-link-check README.md` whenever docs are updated so the docs CI job passes.
+- Run `npx -y markdown-link-check README.md` whenever docs are updated to avoid prompts and keep the docs CI job green.
 - **Each PR requires at least one reviewer.**
 
 ## Decision & Progress Logging

--- a/NOTES.md
+++ b/NOTES.md
@@ -1,4 +1,11 @@
 ## 2025-06-17 PR #XXX
+- **Summary**: clarified docs link check uses `npx -y markdown-link-check` to skip prompts.
+- **Stage**: documentation
+- **Requirements addressed**: N/A
+- **Deviations/Decisions**: kept docs CI workflow consistent with new command.
+- **Next step**: monitor docs pipeline.
+
+## 2025-06-17 PR #XXX
 
 - **Summary**: reorder CI steps so web dependencies install before package tests.
 - **Stage**: implementation

--- a/README.md
+++ b/README.md
@@ -126,9 +126,9 @@ Run tests from each app before pushing:
 cd mobile-app && flutter test
 cd ../web-app && npm test
 ```
-Run the documentation checks with Node 20:
+Run the documentation checks with Node 20 (use `-y` to skip prompts):
 ```bash
-npx markdown-link-check README.md
+npx -y markdown-link-check README.md
 ```
 
 flutter test and npm test – keep CI green


### PR DESCRIPTION
## Summary
- clarify that `npx -y` avoids prompts in docs link check
- mention the same in contributor workflow
- sync README and docs CI workflow with the command
- log decision in NOTES.md

## Testing
- `npx -y markdown-link-check README.md` *(fails: 2 dead links)*

------
https://chatgpt.com/codex/tasks/task_e_685150af8f1083258ec3d76d662da5b8