### PR TITLE
Fix README slug links

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -1,4 +1,11 @@
 ## 2025-06-17 PR #XXX
+- **Summary**: replaced hard-coded owner slug in README badge and clone command.
+- **Stage**: documentation
+- **Requirements addressed**: N/A
+- **Deviations/Decisions**: used <your-user> placeholder for portability.
+- **Next step**: confirm docs link check passes in CI.
+
+## 2025-06-17 PR #XXX
 - **Summary**: fixed NetClient caching tests and location service tests; added flutter_test dep and geolocator stubs.
 - **Stage**: implementation
 - **Requirements addressed**: FR-0104

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Stock-App1 · **SMWA – Stock Market Mobile & Web Application**
 
-[![CI • unit → build → Lighthouse](https://img.shields.io/github/actions/workflow/status/IvanStarostin1984/Stock-App1/ci.yml?branch=main)](./.github/workflows/ci.yml)
+[![CI • unit → build → Lighthouse](https://img.shields.io/github/actions/workflow/status/<your-user>/Stock-App1/ci.yml?branch=main)](./.github/workflows/ci.yml)
 
 > **One code-base → two front-ends**: a Flutter 3 .22 mobile app **and** a responsive Vue-powered PWA that surface *end-of-day* market data **without** busting free-tier API limits.
 
@@ -49,7 +49,7 @@ Detailed setup steps live in `AGENTS.md`.
 
 ```bash
 # 1 · Clone
-git clone https://github.com/IvanStarostin1984/Stock-App1.git
+git clone https://github.com/<your-user>/Stock-App1.git
 cd Stock-App1
 
 # 2 · Generate REST clients

--- a/TODO.md
+++ b/TODO.md
@@ -79,5 +79,5 @@
 - [ ] Investigate flutter analyze errors from generated-dart serializers
 - [x] Update Flutter services to pass ttlMs to NetClient calls
 - [x] Document running `flutter pub get -C mobile-app/packages/services` after REST client generation
-- [ ] Fix README CI badge links for markdown-link-check
+- [x] Fix README CI badge links for markdown-link-check
 - [x] Fix README CI badge links for markdown-link-check


### PR DESCRIPTION
## Summary
- avoid hard-coded owner for CI badge and clone command
- tick README badge TODO
- log update in NOTES

## Testing
- `npx -y markdown-link-check README.md`

------
https://chatgpt.com/codex/tasks/task_e_685157c27eec8325a713a07e8c660f9f