### PR TITLE
docs: record service package test result

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -1,3 +1,10 @@
+## 2025-07-12 PR #XXX
+- **Summary**: re-ran service package tests after installing dependencies; all tests pass.
+- **Stage**: testing
+- **Requirements addressed**: N/A
+- **Deviations/Decisions**: none
+- **Next step**: monitor CI
+
 ## 2025-06-17 PR #XXX
 - **Summary**: fixed NetClient caching tests and location service tests; added flutter_test dep and geolocator stubs.
 - **Stage**: implementation


### PR DESCRIPTION
## Summary
- note that service package tests pass after `flutter pub get`

## Testing
- `flutter test` in `mobile-app/packages/services`
- `npx -y markdown-link-check README.md`
- `npx -y markdownlint-cli README.md NOTES.md TODO.md AGENTS.md`

------
https://chatgpt.com/codex/tasks/task_e_685157c691688325a1fecfae21b1e7fa