### PR TITLE
Add local setup script for packages

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,19 +25,25 @@ This repository hosts a cross-platform stock market app with a Flutter mobile fr
    ```bash
    cd packages
    npm run gen:clients
+   npm ci
    cd ..
    ```
    This script replaces running `npm run gen:ts` and `npm run gen:dart` separately.
 2. Mobile app:
    ```bash
    cd mobile-app
-   flutter pub get && flutter run
+   flutter pub get
+   flutter pub get -C packages/services
+   flutter run
    ```
 3. Web app:
    ```bash
    cd web-app
    npm install && npm run dev
    ```
+Local setup scripts must include `npm ci -C packages` and
+`flutter pub get -C mobile-app/packages/services` so the shared
+packages are ready for tests and analysis.
 4. When TypeScript files outside `web-app/src/` are imported (e.g. under
    `packages/`), update `web-app/tsconfig.json` to include those paths and
    exclude `../packages/**/tests` so vue-tsc skips package tests.

--- a/NOTES.md
+++ b/NOTES.md
@@ -1,4 +1,11 @@
 ## 2025-06-17 PR #XXX
+- **Summary**: added start_env.sh script and updated AGENTS setup steps.
+- **Stage**: documentation
+- **Requirements addressed**: N/A
+- **Deviations/Decisions**: new script ensures packages installs; mobile services dep step after pub get.
+- **Next step**: monitor CI for green build.
+
+## 2025-06-17 PR #XXX
 - **Summary**: fixed NetClient caching tests and location service tests; added flutter_test dep and geolocator stubs.
 - **Stage**: implementation
 - **Requirements addressed**: FR-0104

--- a/TODO.md
+++ b/TODO.md
@@ -81,3 +81,4 @@
 - [x] Document running `flutter pub get -C mobile-app/packages/services` after REST client generation
 - [ ] Fix README CI badge links for markdown-link-check
 - [x] Fix README CI badge links for markdown-link-check
+- [x] Add start_env.sh script to automate local setup

--- a/start_env.sh
+++ b/start_env.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# install web-app dependencies
+npm ci -C web-app
+
+# install shared package dependencies
+npm ci -C packages
+
+# fetch Flutter dependencies
+flutter pub get -C mobile-app
+flutter pub get -C mobile-app/packages/services


### PR DESCRIPTION
## Summary
- add `start_env.sh` for running web/mobile setup
- clarify AGENTS setup steps to fetch service deps and install packages
- log these docs updates

## Testing
- `npm ci --prefix web-app`
- `npm run tokens --prefix web-app`
- `npm test --prefix web-app`
- `npm ci --prefix packages`
- `npm test --prefix packages`
- `dart format -o none .`
- `flutter analyze`
- `(cd mobile-app/packages/services && flutter test)`
- `(cd mobile-app && flutter test)`
- `npx eslint "{src,tests}/**/*.{js,ts,vue}" --fix` within `web-app`
- `npx -y markdown-link-check README.md`


------
https://chatgpt.com/codex/tasks/task_e_685157c50a6c8325a9f98c0bb11b23bc