### PR TITLE
Fix vitest ignore patterns and clarify docs

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -1,3 +1,10 @@
+## 2025-07-18 PR #XX
+- **Summary**: updated vitest coverage patterns to `**/generated-*/**` and clarified README about generated client exclusion and 75% packages coverage.
+- **Stage**: documentation
+- **Requirements addressed**: N/A
+- **Deviations/Decisions**: pattern now independent of working directory.
+- **Next step**: verify CI.
+
 ## 2025-06-18 PR #XX
 - **Summary**: clarified that `<your-user>` placeholders in README and AGENTS should be replaced with your GitHub handle when forking.
 - **Stage**: documentation

--- a/README.md
+++ b/README.md
@@ -131,16 +131,18 @@ Run tests from each app and the shared packages before pushing:
 ```bash
 cd mobile-app && flutter test --coverage
 cd ../web-app && npx vitest run --coverage
-cd ../packages && npm test
+cd ../packages && npx vitest run --coverage
 ```
-The packages suite uses `vitest.config.ts`, which ignores generated clients from coverage.
+The packages suite uses `vitest.config.ts`; its `coverage.exclude` patterns
+(`**/generated-ts/**` and `**/generated-dart/**`) skip the generated REST
+clients.
 Run the documentation checks with Node 20 (use `-y` to skip prompts):
 ```bash
 npx -y markdown-link-check README.md
 ```
 
 flutter test and npm test – keep CI green
-Both suites must report at least 75% coverage.
+All suites, including the packages tests, must report at least 75% coverage.
 
 PR → main, 1 reviewer min.
 

--- a/TODO.md
+++ b/TODO.md
@@ -90,3 +90,5 @@
 - [x] Document installing `@types` packages when adding new JS dependencies to avoid TS7016 errors.
 - [x] Verify RSS fallback on mobile NewsService.
 - [x] Document customizing the `<your-user>` placeholder after forking the repo.
+- [ ] Keep `packages/vitest.config.ts` exclude patterns in sync with README
+      coverage instructions.

--- a/packages/vitest.config.ts
+++ b/packages/vitest.config.ts
@@ -3,6 +3,6 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   coverage: {
     provider: 'v8',
-    exclude: ['./generated-ts/**', './generated-dart/**'],
+    exclude: ['**/generated-ts/**', '**/generated-dart/**'],
   },
 });


### PR DESCRIPTION
## Summary
- exclude generated REST clients in vitest via `**/generated-*/**`
- document the coverage patterns and ≥75% package coverage
- note the change in NOTES and TODO

## Testing
- `./start_env.sh`
- `dart format -o none --set-exit-if-changed mobile-app packages`
- `flutter analyze`
- `flutter test --coverage --dart-define=VITE_NEWSDATA_KEY=dummy --dart-define=VITE_MARKETSTACK_KEY=dummy`
- `npm run lint -C web-app`
- `npm test -C packages`
- `npm test -C web-app`
- `npx -y markdown-link-check README.md`


------
https://chatgpt.com/codex/tasks/task_e_68527e36d5a883259a61eb219ad040e3