### PR TITLE
Fix packages vitest config closing brace

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -1,3 +1,10 @@
+## 2025-06-18 PR #XX
+- **Summary**: fixed test config closing brace so vitest can run.
+- **Stage**: development
+- **Requirements addressed**: N/A
+- **Deviations/Decisions**: inserted missing brace to close test block.
+- **Next step**: run packages tests in CI.
+
 ## 2025-07-18 PR #XX
 - **Summary**: updated vitest coverage patterns to `**/generated-*/**` and clarified README about generated client exclusion and 75% packages coverage.
 - **Stage**: documentation

--- a/packages/vitest.config.ts
+++ b/packages/vitest.config.ts
@@ -7,4 +7,5 @@ export default defineConfig({
       provider: 'v8',
       exclude: ['generated-ts/**', 'generated-dart/**'],
     },
+  },
 });


### PR DESCRIPTION
## Summary
- close `test` block in `packages/vitest.config.ts`
- note fix in NOTES

## Testing
- `npm test` inside `packages/`

------
https://chatgpt.com/codex/tasks/task_e_685298c425cc8325ae20dd39767b7f2e