### PR TITLE
Update README coverage notes

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -1,18 +1,23 @@
-<<<<<<< codex/update-documentation-for-vitest-config
+## 2025-06-18 PR #XX
+- **Summary**: documented coverage exclude paths in README and closed TODO.
+- **Stage**: documentation
+- **Requirements addressed**: N/A
+- **Deviations/Decisions**: README now lists `core/src/**` and `vitest.config.ts` exclusion; TODO ticked.
+- **Next step**: monitor docs CI.
+
 ## 2025-07-19 PR #XX
 - **Summary**: documented new vitest config parsing step in AGENTS.
 - **Stage**: documentation
 - **Requirements addressed**: N/A
 - **Deviations/Decisions**: ensures config errors fail fast.
 - **Next step**: run markdown link check.
-=======
+
 ## 2025-06-18 PR #XX
 - **Summary**: fixed test config closing brace so vitest can run.
 - **Stage**: development
 - **Requirements addressed**: N/A
 - **Deviations/Decisions**: inserted missing brace to close test block.
 - **Next step**: run packages tests in CI.
->>>>>>> main
 
 ## 2025-07-18 PR #XX
 - **Summary**: updated vitest coverage patterns to `**/generated-*/**` and clarified README about generated client exclusion and 75% packages coverage.

--- a/README.md
+++ b/README.md
@@ -134,8 +134,8 @@ cd ../web-app && npx vitest run --coverage
 cd ../packages && npx vitest run --coverage
 ```
 The packages suite uses `vitest.config.ts`; its `coverage.exclude` patterns
-(`**/generated-ts/**` and `**/generated-dart/**`) skip the generated REST
-clients.
+(`**/generated-ts/**`, `**/generated-dart/**`, `core/src/**` and
+`vitest.config.ts`) skip the generated REST clients and helper files.
 Run the documentation checks with Node 20 (use `-y` to skip prompts):
 ```bash
 npx -y markdown-link-check README.md

--- a/TODO.md
+++ b/TODO.md
@@ -91,7 +91,7 @@
 - [x] Document installing `@types` packages when adding new JS dependencies to avoid TS7016 errors.
 - [x] Verify RSS fallback on mobile NewsService.
 - [x] Document customizing the `<your-user>` placeholder after forking the repo.
-- [ ] Keep `packages/vitest.config.ts` exclude patterns in sync with README
-      coverage instructions.
+ - [x] Keep `packages/vitest.config.ts` exclude patterns in sync with README
+       coverage instructions.
 - [ ] Maintain >75% coverage for packages tests
 - [ ] Add linter or pre-test step that verifies vitest config syntax parses.


### PR DESCRIPTION
## Summary
- document new coverage.exclude paths for packages in README
- tick README sync TODO item
- log changes in NOTES

## Testing
- `npx -y markdown-link-check README.md`
- `npx -y markdownlint-cli README.md` *(fails: MD013 line length warnings etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6852a18937b88325bdae1eb441caccee