### PR TITLE
Fix CI design tokens build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,9 @@ jobs:
       - name: Install web dependencies
         run: npm ci
         working-directory: web-app
+      - name: Build design tokens
+        run: npm run tokens
+        working-directory: web-app
       - name: Install package dependencies
         run: npm ci
         working-directory: packages

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,6 +102,7 @@ caching period. Free‑tier quotas remain ≤ 100 Marketstack/FX calls · month�
 - After generating REST clients, run `flutter pub get -C mobile-app/packages/services` so
   the service package has its dependencies ready.
 - Run `npm run tokens` (or run tests) before any Flutter analysis or build steps so `tokens.dart` exists.
+- Run `npm run tokens` before web tests if you invoke `npx vitest` or `npx jest` directly. Their pretest hook does not run automatically.
 - Flutter tests require API keys via `--dart-define`:
   `flutter test --dart-define=VITE_NEWSDATA_KEY=dummy --dart-define=VITE_MARKETSTACK_KEY=dummy`.
 - `mobile-app/packages/services` uses Flutter plugins, so its tests must run via `flutter test` (not `dart test`).

--- a/NOTES.md
+++ b/NOTES.md
@@ -1,3 +1,10 @@
+## 2025-07-21 PR #XX
+- **Summary**: fixed CI tests failing due to missing design tokens.
+- **Stage**: bug fix
+- **Requirements addressed**: N/A
+- **Deviations/Decisions**: CI now runs `npm run tokens` before Node tests; AGENTS updated.
+- **Next step**: monitor pipeline for green status.
+
 ## 2025-06-18 PR #XX
 - **Summary**: documented coverage exclude paths in README and closed TODO.
 - **Stage**: documentation


### PR DESCRIPTION
## Summary
- run `npm run tokens` before tests
- document pretest requirement in AGENTS
- log CI change in NOTES

## Testing
- `npm run tokens` *(passes)*
- `npx vitest run` *(fails: requires install)*

------
https://chatgpt.com/codex/tasks/task_e_6852a5941c848325a9ef73ee1d9ecd6d