### PR TITLE
Update Flutter test keys in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,10 +63,10 @@ jobs:
       - name: Run service package tests with coverage
         run: |
           flutter pub get
-          VITE_NEWSDATA_KEY=test flutter test --coverage
+          flutter test --coverage --dart-define=VITE_NEWSDATA_KEY=test
         working-directory: mobile-app/packages/services
       - name: Run Flutter tests with coverage
-        run: VITE_NEWSDATA_KEY=test flutter test --coverage
+        run: flutter test --coverage --dart-define=VITE_NEWSDATA_KEY=test
         working-directory: mobile-app
       - name: Build
         run: npm run build

--- a/.github/workflows/flutter_test.yml
+++ b/.github/workflows/flutter_test.yml
@@ -25,8 +25,8 @@ jobs:
       - name: Run service package tests
         run: |
           flutter pub get
-          flutter test
+          flutter test --dart-define=VITE_NEWSDATA_KEY=test
         working-directory: mobile-app/packages/services
       - name: Run Flutter tests
-        run: flutter test
+        run: flutter test --dart-define=VITE_NEWSDATA_KEY=test
         working-directory: mobile-app

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -103,8 +103,9 @@ caching period. Free‑tier quotas remain ≤ 100 Marketstack/FX calls · month�
   the service package has its dependencies ready.
 - Run `npm run tokens` (or run tests) before any Flutter analysis or build steps so `tokens.dart` exists.
 - Run `npm run tokens` before web tests if you invoke `npx vitest` or `npx jest` directly. Their pretest hook does not run automatically.
-- Flutter tests require API keys via `--dart-define`:
-  `flutter test --dart-define=VITE_NEWSDATA_KEY=dummy --dart-define=VITE_MARKETSTACK_KEY=dummy`.
+- Flutter tests require API keys via `--dart-define`. CI passes a dummy NewsData key:
+  `flutter test --dart-define=VITE_NEWSDATA_KEY=test`.
+  Include `--dart-define=VITE_MARKETSTACK_KEY=dummy` locally if Marketstack API calls run in tests.
 - `mobile-app/packages/services` uses Flutter plugins, so its tests must run via `flutter test` (not `dart test`).
 - The shared packages under `packages/` install via `npm ci` and run `npm test` in CI.
 - Run the documentation link check with Node 20 (use `-y` to skip prompts):

--- a/NOTES.md
+++ b/NOTES.md
@@ -1,3 +1,10 @@
+## 2025-07-22 PR #XX
+- **Summary**: CI now supplies Flutter tests with a dummy API key via `--dart-define`.
+- **Stage**: maintenance
+- **Requirements addressed**: N/A
+- **Deviations/Decisions**: workflows call `flutter test --dart-define=VITE_NEWSDATA_KEY=test`.
+- **Next step**: monitor CI for failures.
+
 ## 2025-07-21 PR #XX
 - **Summary**: fixed CI tests failing due to missing design tokens.
 - **Stage**: bug fix

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ The PWA's services now live directly under `web-app/src/services/`; the old
 ⚙️ Useful Scripts
 Task	Mobile	Web
 Dev hot-reload	flutter run	npm run dev
-Unit tests      flutter test (in mobile-app/)    npm test (in web-app/)
+Unit tests      flutter test --dart-define VITE_NEWSDATA_KEY=test --coverage (in mobile-app/)    npm test (in web-app/)
 Lint / format	dart format .	npm run lint
 REST clients    –               npm run gen:clients (in packages/)
 Build (CI)	GitHub Action → Netlify preview	(same)
@@ -129,7 +129,7 @@ Fork → branch feat/<topic>
 
 Run tests from each app and the shared packages before pushing:
 ```bash
-cd mobile-app && flutter test --coverage
+cd mobile-app && flutter test --dart-define VITE_NEWSDATA_KEY=test --coverage
 cd ../web-app && npx vitest run --coverage
 cd ../packages && npx vitest run --coverage
 ```

--- a/TODO.md
+++ b/TODO.md
@@ -88,6 +88,7 @@
 - [x] Fix README CI badge links for markdown-link-check
 - [x] Fix README CI badge links for markdown-link-check
 - [x] Add start_env.sh script to automate local setup
+- [x] Update CI workflows to pass API keys via `--dart-define`
 - [ ] Add type stubs for crypto libraries and document tsconfig changes
 - [x] Document installing `@types` packages when adding new JS dependencies to avoid TS7016 errors.
 - [x] Verify RSS fallback on mobile NewsService.


### PR DESCRIPTION
## Summary
- pass `VITE_NEWSDATA_KEY` via `--dart-define` in Flutter CI jobs
- apply same flag to PR smoke tests
- document new test command in README
- note workflow update in TODO and NOTES
- clarify Flutter test keys in AGENTS guide

## Testing
- `npx -y markdown-link-check README.md`

------
https://chatgpt.com/codex/tasks/task_e_6852ad9154388325934926ea5a05b4ba