### PR TITLE
Document prototype tokens

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,6 +62,9 @@ LHCI_GITHUB_APP_TOKEN=YOUR_LHCI_TOKEN  # CI only
 ```
 (Exchangerate.host is key-less – no variable needed.)
 
+## Design Reference
+The folder `web-prototype/` contains HTML/CSS exported from Figma. Treat it as read-only. Copy colours, fonts and layout cues into `web-app/design-tokens/tokens.json` and Vue pages rather than importing the raw files.
+
 ## API hygiene
 (API requests are implemented in service classes under `web-app/src/services/`.)
 Each service uses `LruCache`, `ApiQuotaLedger` and the shared `NetClient`

--- a/NOTES.md
+++ b/NOTES.md
@@ -1,3 +1,10 @@
+## 2025-06-18 PR #XX
+- **Summary**: documented how web-prototype guides design tokens.
+- **Stage**: documentation
+- **Requirements addressed**: N/A
+- **Deviations/Decisions**: web-prototype stays read-only; tokens copied to web-app.
+- **Next step**: integrate new tokens into Vue pages.
+
 ## 2025-07-23 PR #XX
 - **Summary**: added web-prototype folder for design mockups.
 - **Stage**: planning

--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ matching repository backed by `localStorage`.
 packages/           shared DTOs + generated REST clients
 mobile-app/         Flutter application (6 screens)
 web-app/            PWA (Vue 3 + Vite, 7 pages)
+web-prototype/      Figma HTML/CSS reference (read only).
+                    Tokens in `web-app/design-tokens/tokens.json` mirror its colours and fonts.
 .github/workflows/  CI → unit → build → Lighthouse → Netlify deploy
 docs/               full ISO/IEC 29148 SRS, architecture, slides
 🔒 Free-Tier Guardrails (LIM-0003 … 0007 / 0016)

--- a/TODO.md
+++ b/TODO.md
@@ -100,3 +100,6 @@
 - [ ] Maintain >75% coverage for packages tests
 - [ ] Add linter or pre-test step that verifies vitest config syntax parses.
 - [x] Create web-prototype directory with placeholder HTML pages for design.
+- [ ] Import colours and fonts from `web-prototype/CSS/styleguide.css` into `web-app/design-tokens/tokens.json`.
+- [ ] Bundle prototype fonts in the PWA (verify licenses).
+- [ ] Rebuild Vue pages to match `web-prototype/*.html` using the new tokens.

--- a/web-app/README.md
+++ b/web-app/README.md
@@ -36,6 +36,8 @@ cached for 12 hours just like the API data.
 
 Run `npm run tokens` to generate `design-tokens/build/css/tokens.scss` and `design-tokens/build/dart/tokens.dart`. These files are regenerated automatically during `npm run build` and before tests.
 
+Tokens come from `web-prototype/CSS/styleguide.css`. Copy its colour and font variables into `design-tokens/tokens.json` and use them via the generated CSS variables.
+
 Run this command (or `npm test`, which also triggers it) **before** running any
 Flutter analysis or build steps so `tokens.dart` exists.
 


### PR DESCRIPTION
## Summary
- document role of the Figma prototype
- explain that tokens come from `web-prototype`
- list the prototype directory in the repo layout
- add TODO tasks for using prototype colours/fonts
- note the change in NOTES

## Testing
- `npx -y markdown-link-check README.md AGENTS.md web-app/README.md`

------
https://chatgpt.com/codex/tasks/task_e_6852bb7de390832595468a9403401900