### PR TITLE
Update docs about vitest-config lint reporter

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -136,6 +136,8 @@ caching period. Free‑tier quotas remain ≤ 100 Marketstack/FX calls · month�
   config file `packages/vitest.config.ts`. Keep this list in sync with the
   README and `packages/vitest.config.ts` itself.
  - After editing `packages/vitest.config.ts` (or any vitest config), run `npm run lint:vitest-config` to ensure it parses.
+   This command relies on Vitest's built‑in `dot` reporter, so avoid
+   overriding `--reporter` when editing it.
  - CI runs this script right after installing package dependencies so broken config files fail early.
 
 # Quality gates

--- a/NOTES.md
+++ b/NOTES.md
@@ -1,3 +1,10 @@
+## 2025-07-28 PR #XX
+- **Summary**: clarified AGENTS instructions for `lint:vitest-config` to mention the built-in dot reporter.
+- **Stage**: documentation
+- **Requirements addressed**: N/A
+- **Deviations/Decisions**: command relies on dot reporter; avoid custom `--reporter` flags.
+- **Next step**: monitor future changes for reporter drift.
+
 ## 2025-06-18 PR #XX
 - **Summary**: bundled SF Pro fonts from prototype, added @font-face rules, updated attribution.
 - **Stage**: implementation
@@ -1080,3 +1087,4 @@ npm test
 - **Requirements addressed**: N/A
 - **Deviations/Decisions**: emphasised Node 20; doc link check via npx.
 - **Next step**: add automated job for docs.
+


### PR DESCRIPTION
## Summary
- clarify that `npm run lint:vitest-config` uses the built-in dot reporter
- log the update in NOTES

## Testing
- `npx -y markdown-link-check README.md`
- ❌ `npx -y markdownlint '**/*.md' '!**/node_modules/**'` (failed: could not determine executable)


------
https://chatgpt.com/codex/tasks/task_e_685513e086c083259f17d979e2a73d74