### PR TITLE
Fix notes order and document chronology rule

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -189,6 +189,7 @@ Append **one new section at the top of `NOTES.md`** (newest entry first) using t
 - **Next step**: …
 - **Notes**: … (optional)
 ```
+- Older entries must never precede newer ones; keep the log newest first.
 Agents MUST consult Notes.md and the referenced requirement IDs before starting work
 to understand the current stage, past decisions, and open questions tied to the spec.
 

--- a/NOTES.md
+++ b/NOTES.md
@@ -1,9 +1,9 @@
-## 2025-06-20 PR #XX
-- **Summary**: changed vitest config lint script to use dot reporter.
-- **Stage**: maintenance
+## 2025-07-29 PR #XX
+- **Summary**: reordered log entries and updated AGENTS about keeping notes newest-first.
+- **Stage**: documentation
 - **Requirements addressed**: N/A
-- **Deviations/Decisions**: replaced invalid reporter to fix script.
-- **Next step**: verify CI passes.
+- **Deviations/Decisions**: none
+- **Next step**: follow updated logging rule.
 
 ## 2025-07-28 PR #XX
 - **Summary**: clarified AGENTS instructions for `lint:vitest-config` to mention the built-in dot reporter.
@@ -11,6 +11,13 @@
 - **Requirements addressed**: N/A
 - **Deviations/Decisions**: command relies on dot reporter; avoid custom `--reporter` flags.
 - **Next step**: monitor future changes for reporter drift.
+
+## 2025-06-20 PR #XX
+- **Summary**: changed vitest config lint script to use dot reporter.
+- **Stage**: maintenance
+- **Requirements addressed**: N/A
+- **Deviations/Decisions**: replaced invalid reporter to fix script.
+- **Next step**: verify CI passes.
 
 ## 2025-06-18 PR #XX
 - **Summary**: bundled SF Pro fonts from prototype, added @font-face rules, updated attribution.

--- a/TODO.md
+++ b/TODO.md
@@ -7,6 +7,7 @@
 - [x] Introduce NetClient class in Dart services and update tests.
 
 - [x] Resolved merge conflict in NOTES.md and preserved entry order.
+- [x] Documented rule to keep NOTES.md chronological and reordered entries.
 # Outstanding Tasks
 - [x] Add parity tests for NewsService
 - [x] Implement RSS fallback in mobile NewsService


### PR DESCRIPTION
## Summary
- keep NOTES.md in reverse chronological order
- note the rule in AGENTS.md that older entries never precede newer ones
- record this fix in NOTES.md
- update TODO item about log order

## Testing
- `npx -y markdownlint-cli AGENTS.md NOTES.md TODO.md README.md`
- `npx -y markdown-link-check README.md`


------
https://chatgpt.com/codex/tasks/task_e_685a78a904c48325ab8ef851da670dc1