### PR TITLE
Ignore generated Dart in analyzer

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,7 +106,8 @@ caching period. Free‑tier quotas remain ≤ 100 Marketstack/FX calls · month�
 ## Testing & CI
 - Run `dart format`, `flutter analyze`, `flutter test`, `eslint --fix`, and `npm test` before committing.
 - `flutter analyze` at the repo root uses `analysis_options.yaml` which includes
-  `mobile-app/analysis_options.yaml` and excludes generated design tokens.
+  `mobile-app/analysis_options.yaml` and excludes generated design tokens and the
+  OpenAPI client under `packages/generated-dart`.
 - Run `npm install` in `web-app/` before tests so the style-dictionary build step works.
 - Package tests import utilities from `web-app/src/`, so run `npm ci` in `web-app/` before executing tests in `packages/`.
 - After setting up Node, run `npm ci` and `npm test` in `packages/` to verify the

--- a/NOTES.md
+++ b/NOTES.md
@@ -1,3 +1,9 @@
+## 2025-06-24 PR #XX
+- **Summary**: excluded generated Dart client from analyzer to silence errors.
+- **Stage**: maintenance
+- **Requirements addressed**: N/A
+- **Deviations/Decisions**: opted to ignore auto-generated code rather than modify it.
+- **Next step**: ensure CI stays green
 ## 2025-06-20 PR #XX
 - **Summary**: changed vitest config lint script to use dot reporter.
 - **Stage**: maintenance

--- a/TODO.md
+++ b/TODO.md
@@ -85,7 +85,7 @@
 - [ ] Verify tsconfig excludes to ensure package tests are ignored.
 - [x] Add vitest config in packages to ignore generated clients from coverage.
 - [x] Moved coverage exclusions under test.coverage to fix generated clients in reports.
-- [ ] Investigate flutter analyze errors from generated-dart serializers
+- [x] Investigate flutter analyze errors from generated-dart serializers
 - [x] Update Flutter services to pass ttlMs to NetClient calls
 - [x] Document running `flutter pub get -C mobile-app/packages/services` after REST client generation
 - [x] Fix README CI badge links for markdown-link-check

--- a/packages/generated-dart/analysis_options.yaml
+++ b/packages/generated-dart/analysis_options.yaml
@@ -4,6 +4,7 @@ analyzer:
     strict-raw-types: true
     strict-casts: false
   exclude:
+    - lib/**
     - test/*.dart
   errors:
     deprecated_member_use_from_same_package: ignore


### PR DESCRIPTION
## Summary
- add analyzer exclusion for `packages/generated-dart`
- note exclusion in AGENTS
- log investigation result in NOTES
- tick related TODO item

## Testing
- `flutter analyze`
- `flutter analyze packages/generated-dart`
- `flutter test --dart-define=VITE_NEWSDATA_KEY=test` (mobile)
- `npm test` (packages)
- `npm test` (web)

------
https://chatgpt.com/codex/tasks/task_e_685a78ac52fc832591c43bba8e08d6b1