### PR TITLE
Add watch list page and store actions

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -1,4 +1,11 @@
 ## 2025-06-24 PR #XX
+- **Summary**: added watch list page and store actions for managing symbols; registered route and tests.
+- **Stage**: implementation
+- **Requirements addressed**: UC-15
+- **Deviations/Decisions**: storing watch list locally despite SRS scope.
+- **Next step**: monitor coverage and integrate UI for editing list.
+
+## 2025-06-24 PR #XX
 - **Summary**: added WatchListRepository and updated syncWatchList action to persist symbols via localStorage.
 - **Stage**: implementation
 - **Requirements addressed**: UC-15

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ LHCI_GITHUB_APP_TOKEN=YOUR_LHCI_TOKEN  # CI only
 | **Detail** | 🕰 *Interactive OHLC charts* (1 d / 1 m / 3 m / 1 y) | PF-002·FR-0102 |
 | **News + Prices** | 💹 *Top 5 gainers & losers* · 📰 *News digest* (NewsData.io → RSS fallback) | PF-003/004·FR-0103/0104 |
 | **Portfolio** | 👜 *Local tracker* with hourly auto-refresh; EUR ↔ USD ↔ local toggle | PF-006/007·FR-0106/0107 |
+| **Watch List** | 📝 *Saved symbols stored locally* | – |
 | **Pro** | ⭐ *Mock “Pro” upgrade* via `stripe-mock` | PF-008·FR-0108 |
 
 > **Exam-spec quirks covered**<br>
@@ -86,7 +87,7 @@ matching repository backed by `localStorage`.
 📂 Repo Layout
 packages/           shared DTOs + generated REST clients
 mobile-app/         Flutter application (6 screens)
-web-app/            PWA (Vue 3 + Vite, 7 pages)
+web-app/            PWA (Vue 3 + Vite, 8 pages)
 web-prototype/      Figma HTML/CSS reference (read only).
                     Colours and font names in `web-app/design-tokens/tokens.json`
                     come from `web-prototype/CSS/styleguide.css`. Font families

--- a/TODO.md
+++ b/TODO.md
@@ -1,6 +1,8 @@
 - [x] Split font weights from font family tokens for easier CSS usage.
 # TODO
 
+- [x] Add WatchListPage and store actions for watch list.
+
 - [x] Implement a unified network layer shared by mobile and web services.
 - [x] Implement local WatchListRepository for web
 - [x] Refactor mobile (Flutter) services to use NetClient.

--- a/web-app/src/pages/WatchListPage.vue
+++ b/web-app/src/pages/WatchListPage.vue
@@ -1,0 +1,36 @@
+<template>
+  <div class="page">
+    <h1>Watch List</h1>
+    <ul>
+      <li v-for="s in symbols" :key="s">{{ s }}</li>
+    </ul>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { onMounted, ref } from 'vue';
+import { WatchListRepository } from '@/repositories/WatchListRepository';
+import { useLoadTimeLogger } from '@/utils/useLoadTimeLogger';
+
+const repo = new WatchListRepository();
+const symbols = ref<string[]>([]);
+
+onMounted(async () => {
+  symbols.value = await repo.list();
+});
+
+useLoadTimeLogger('WatchListPage');
+</script>
+
+<style scoped>
+.page {
+  padding: var(--space-grid-4);
+  font-family: var(--font-family-sf-pro-text);
+  font-weight: var(--font-weight-regular);
+}
+h1 {
+  font-family: var(--font-family-sf-pro-display);
+  font-weight: var(--font-weight-bold);
+  color: var(--clr-primary-700);
+}
+</style>

--- a/web-app/src/router.ts
+++ b/web-app/src/router.ts
@@ -4,6 +4,7 @@ import SearchPage from '@/pages/SearchPage.vue';
 import DetailPage from '@/pages/DetailPage.vue';
 import NewsPricesPage from '@/pages/NewsPricesPage.vue';
 import PortfolioPage from '@/pages/PortfolioPage.vue';
+import WatchListPage from '@/pages/WatchListPage.vue';
 import ProPage from '@/pages/ProPage.vue';
 import LoginPage from '@/pages/LoginPage.vue';
 
@@ -13,6 +14,7 @@ const routes = [
   { path: '/detail/:symbol?', name: 'detail', component: DetailPage },
   { path: '/news-prices', name: 'news-prices', component: NewsPricesPage },
   { path: '/portfolio', name: 'portfolio', component: PortfolioPage },
+  { path: '/watchlist', name: 'watchlist', component: WatchListPage },
   { path: '/pro', name: 'pro', component: ProPage },
   { path: '/login', name: 'login', component: LoginPage }
 ];

--- a/web-app/src/stores/appStore.ts
+++ b/web-app/src/stores/appStore.ts
@@ -29,6 +29,7 @@ export interface AppDeps {
   trie?: SymbolTrie;
   locationService?: LocationService;
   countryRepo?: CountrySettingRepository;
+  watchRepo?: WatchListRepository;
 }
 
 export function createAppStore(deps: AppDeps = {}) {
@@ -102,9 +103,28 @@ export function createAppStore(deps: AppDeps = {}) {
       },
       async syncWatchList() {
         if (typeof localStorage === 'undefined') return;
-        const repo = new WatchListRepository();
+        const repo = deps.watchRepo ?? new WatchListRepository();
         const list = await repo.list();
         await repo.save(list);
+      },
+      /** Add a symbol to the watch list if not already present. */
+      async addToWatchList(symbol: string) {
+        const repo = deps.watchRepo ?? new WatchListRepository();
+        const list = await repo.list();
+        if (!list.includes(symbol)) {
+          list.push(symbol);
+          await repo.save(list);
+        }
+      },
+      /** Remove a symbol from the watch list. */
+      async removeFromWatchList(symbol: string) {
+        const repo = deps.watchRepo ?? new WatchListRepository();
+        const list = await repo.list();
+        const idx = list.indexOf(symbol);
+        if (idx !== -1) {
+          list.splice(idx, 1);
+          await repo.save(list);
+        }
       }
     }
   });

--- a/web-app/tests/WatchListActions.test.ts
+++ b/web-app/tests/WatchListActions.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { createPinia, setActivePinia } from 'pinia';
+import { createAppStore } from '../src/stores/appStore';
+import { QuoteRepository } from '../src/repositories/QuoteRepository';
+
+beforeEach(() => {
+  setActivePinia(createPinia());
+});
+
+describe('watch list actions', () => {
+  it('adds symbol when not present', async () => {
+    const list = vi.fn().mockResolvedValue(['AAPL']);
+    const save = vi.fn();
+    const store = createAppStore({
+      watchRepo: { list, save } as any,
+      quoteRepo: new QuoteRepository({ getQuote: vi.fn() } as any),
+      newsService: { getNews: vi.fn() } as any,
+      fxService: { getRate: vi.fn() } as any,
+      trie: { search: vi.fn().mockReturnValue([]) } as any
+    })();
+    await store.addToWatchList('GOOG');
+    expect(save).toHaveBeenCalledWith(['AAPL', 'GOOG']);
+  });
+
+  it('does not duplicate symbol', async () => {
+    const list = vi.fn().mockResolvedValue(['AAPL']);
+    const save = vi.fn();
+    const store = createAppStore({
+      watchRepo: { list, save } as any,
+      quoteRepo: new QuoteRepository({ getQuote: vi.fn() } as any),
+      newsService: { getNews: vi.fn() } as any,
+      fxService: { getRate: vi.fn() } as any,
+      trie: { search: vi.fn().mockReturnValue([]) } as any
+    })();
+    await store.addToWatchList('AAPL');
+    expect(save).not.toHaveBeenCalled();
+  });
+
+  it('removes symbol when present', async () => {
+    const list = vi.fn().mockResolvedValue(['AAPL', 'GOOG']);
+    const save = vi.fn();
+    const store = createAppStore({
+      watchRepo: { list, save } as any,
+      quoteRepo: new QuoteRepository({ getQuote: vi.fn() } as any),
+      newsService: { getNews: vi.fn() } as any,
+      fxService: { getRate: vi.fn() } as any,
+      trie: { search: vi.fn().mockReturnValue([]) } as any
+    })();
+    await store.removeFromWatchList('GOOG');
+    expect(save).toHaveBeenCalledWith(['AAPL']);
+  });
+});

--- a/web-app/tests/WatchListPage.test.ts
+++ b/web-app/tests/WatchListPage.test.ts
@@ -1,0 +1,24 @@
+import { mount } from '@vue/test-utils';
+import { describe, it, expect, beforeEach } from 'vitest';
+import WatchListPage from '../src/pages/WatchListPage.vue';
+import 'fake-indexeddb/auto';
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+describe('WatchListPage', () => {
+  it('renders saved symbols', async () => {
+    localStorage.setItem('watch_list', JSON.stringify(['AAPL', 'GOOG']));
+    const wrapper = mount(WatchListPage);
+    await new Promise(r => setTimeout(r, 0));
+    expect(wrapper.text()).toContain('AAPL');
+    expect(wrapper.text()).toContain('GOOG');
+  });
+
+  it('renders empty list when none saved', async () => {
+    const wrapper = mount(WatchListPage);
+    await new Promise(r => setTimeout(r, 0));
+    expect(wrapper.findAll('li').length).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- show saved symbols on new WatchListPage
- manage watch list with add/remove actions in app store
- expose page via router
- test watch list store actions and page output
- document new page and update progress notes

## Major design decisions
- Watch list persistence remains local per NOTES.md though spec defers cloud sync.

## Requirements addressed
- UC-15

## Deviations/Decisions
- Local persistence for watch list kept despite SRS noting persistent watch list as out-of-scope.

## Blockers/limitations
- none


------
https://chatgpt.com/codex/tasks/task_e_685a8f11ca80832593252b02a70e514e