### PR TITLE
Add WatchListRepository to mobile app

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -1,3 +1,10 @@
+## 2025-08-01 PR #XX
+- **Summary**: added mobile WatchListRepository using SharedPreferences and updated state to sync watch list on PortfolioScreen.
+- **Stage**: implementation
+- **Requirements addressed**: R-04
+- **Deviations/Decisions**: kept syncWatchList simple (load/save) per MVP design.
+- **Next step**: expand tests around state notifier.
+
 ## 2025-06-24 PR #XX
 - **Summary**: added WatchListRepository and updated syncWatchList action to persist symbols via localStorage.
 - **Stage**: implementation

--- a/TODO.md
+++ b/TODO.md
@@ -3,6 +3,8 @@
 
 - [x] Implement a unified network layer shared by mobile and web services.
 - [x] Implement local WatchListRepository for web
+- [x] Implement WatchListRepository for mobile
+- [x] Expose syncWatchList via AppStateNotifier and PortfolioScreen
 - [x] Refactor mobile (Flutter) services to use NetClient.
 - [x] Implement a unified network layer shared by mobile and web services.
 - [x] Introduce NetClient class in Dart services and update tests.

--- a/mobile-app/lib/repositories/watch_list_repository.dart
+++ b/mobile-app/lib/repositories/watch_list_repository.dart
@@ -1,0 +1,25 @@
+import 'dart:convert';
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// R-04 – Persist watch-list symbols locally.
+class WatchListRepository {
+  static const _key = 'watch_list';
+
+  /// Saves [list] of symbols to SharedPreferences.
+  Future<void> save(List<String> list) async {
+    if (list.any((s) => s.isEmpty)) {
+      throw ArgumentError('Invalid watch list');
+    }
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(_key, json.encode(list));
+  }
+
+  /// Loads the saved watch list or an empty array.
+  Future<List<String>> list() async {
+    final prefs = await SharedPreferences.getInstance();
+    final stored = prefs.getString(_key);
+    if (stored == null) return [];
+    final List<dynamic> data = json.decode(stored);
+    return data.cast<String>();
+  }
+}

--- a/mobile-app/lib/screens/portfolio/portfolio_screen.dart
+++ b/mobile-app/lib/screens/portfolio/portfolio_screen.dart
@@ -15,6 +15,7 @@ class _PortfolioScreenState extends ConsumerState<PortfolioScreen> {
   @override
   void initState() {
     super.initState();
+    ref.read(appStateProvider.notifier).syncWatchList();
     ref.read(portfolioNotifierProvider.notifier).load();
   }
 

--- a/mobile-app/lib/state/app_state.dart
+++ b/mobile-app/lib/state/app_state.dart
@@ -3,6 +3,7 @@ import 'package:smwa_services/services.dart';
 import '../repositories/quote_repository.dart';
 import '../models/quote.dart';
 import '../models/news_article.dart';
+import '../repositories/watch_list_repository.dart';
 
 /// Simple state container used by the app.
 class AppState {
@@ -27,14 +28,19 @@ class AppStateNotifier extends StateNotifier<AppState> {
   final QuoteRepository _quotes;
   final NewsService _news;
   final AuthService _auth;
+  final WatchListRepository _watchRepo;
 
   /// Creates an [AppStateNotifier] with optional service overrides.
   AppStateNotifier(
-      {QuoteRepository? quotes, NewsService? news, AuthService? auth})
+      {QuoteRepository? quotes,
+      NewsService? news,
+      AuthService? auth,
+      WatchListRepository? watchRepo})
       : _quotes = quotes ?? QuoteRepository(),
         _news = news ??
             NewsService(const String.fromEnvironment('VITE_NEWSDATA_KEY')),
         _auth = auth ?? AuthService(),
+        _watchRepo = watchRepo ?? WatchListRepository(),
         super(const AppState());
 
   /// Increments the counter by one.
@@ -59,6 +65,12 @@ class AppStateNotifier extends StateNotifier<AppState> {
   /// Registers a new account via [AuthService].
   Future<Map<String, dynamic>> register(String email, String password) async {
     return _auth.register(email, password);
+  }
+
+  /// Loads and re-saves the watch list.
+  Future<void> syncWatchList() async {
+    final list = await _watchRepo.list();
+    await _watchRepo.save(list);
   }
 }
 

--- a/mobile-app/test/watch_list_repository_test.dart
+++ b/mobile-app/test/watch_list_repository_test.dart
@@ -1,0 +1,31 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:mobile_app/repositories/watch_list_repository.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('WatchListRepository', () {
+    setUp(() {
+      SharedPreferences.setMockInitialValues({});
+    });
+
+    test('saves and loads symbols', () async {
+      final repo = WatchListRepository();
+      await repo.save(['AAPL', 'GOOG']);
+      final list = await repo.list();
+      expect(list, ['AAPL', 'GOOG']);
+    });
+
+    test('returns empty list when no data', () async {
+      final repo = WatchListRepository();
+      final list = await repo.list();
+      expect(list, isEmpty);
+    });
+
+    test('rejects invalid list', () async {
+      final repo = WatchListRepository();
+      expect(() => repo.save(['AAPL', '']), throwsArgumentError);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- implement WatchListRepository in Flutter using SharedPreferences
- expose `syncWatchList` in `AppStateNotifier`
- trigger watch list sync on `PortfolioScreen`
- test watch list persistence
- document progress

## Decision checklist
- Major design decisions: keep sync simple load/save as in MVP
- Deviations: none
- Blockers: `flutter analyze` reports warnings but tests pass
- Requirements addressed: R-04


------
https://chatgpt.com/codex/tasks/task_e_685a8f138c508325bb2785ec3ab3f6c2