### PR TITLE
docs: clarify notes lint reminder

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -143,6 +143,7 @@ caching period. Free‑tier quotas remain ≤ 100 Marketstack/FX calls · month�
   overriding `--reporter` when editing it.
 - CI runs this script right after installing package dependencies so broken config files fail early.
 - Run `npm run lint:notes` to verify `NOTES.md` entries remain newest-first. CI runs this before tests.
+- Always append new sections at the top of `NOTES.md`. After rebasing or resolving merge conflicts, run `npm run lint:notes` again to confirm the order.
 
 # Quality gates
 * **Lighthouse** perf & a11y ≥ 90 or CI fails.  

--- a/NOTES.md
+++ b/NOTES.md
@@ -1,3 +1,10 @@
+## 2025-08-02 PR #XX
+- **Summary**: documented notes merge check and reminder.
+- **Stage**: documentation
+- **Requirements addressed**: N/A
+- **Deviations/Decisions**: none
+- **Next step**: follow rule when resolving conflicts.
+
 ## 2025-08-01 PR #XX
 - **Summary**: added notes order check in CI and updated docs.
 - **Stage**: implementation


### PR DESCRIPTION
## Summary
- remind contributors to re-run `npm run lint:notes` when rebasing or fixing conflicts
- log update about the documentation rule

## Testing
- `npx -y markdown-link-check README.md`
- `npm run --silent lint:notes`

------
https://chatgpt.com/codex/tasks/task_e_685c58b38d00832585d0ef4ee6bc56a0