### PR TITLE
Fix leftover merge markers in NOTES

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -1,17 +1,9 @@
 ## 2025-08-02 PR #XX
-<<<<<<< codex/update-agents.md-with-lint-notes-reminder
-- **Summary**: documented notes merge check and reminder.
-- **Stage**: documentation
-- **Requirements addressed**: N/A
-- **Deviations/Decisions**: none
-- **Next step**: follow rule when resolving conflicts.
-=======
-- **Summary**: reordered NOTES.md chronologically and verified linter.
+- **Summary**: documented notes merge check reminder and reordered NOTES.md chronologically; verified linter.
 - **Stage**: documentation
 - **Requirements addressed**: N/A
 - **Deviations/Decisions**: used script to sort entries.
-- **Next step**: keep notes log newest-first.
->>>>>>> main
+- **Next step**: follow rule when resolving conflicts and keep notes log newest-first.
 
 ## 2025-08-01 PR #XX
 - **Summary**: added notes order check in CI and updated docs.

--- a/TODO.md
+++ b/TODO.md
@@ -13,6 +13,7 @@
 
 - [x] Resolved merge conflict in NOTES.md and preserved entry order.
 - [x] Documented rule to keep NOTES.md chronological and reordered entries.
+- [x] Removed leftover merge markers from NOTES.md entry on 2025-08-02 and combined summaries.
 # Outstanding Tasks
 - [x] Add parity tests for NewsService
 - [x] Extend NewsService parity tests for TTL, ledger and RSS fallback


### PR DESCRIPTION
## Summary
- cleanup merge conflict markers in NOTES
- ensure notes order is correct
- log cleanup in TODO

## Testing
- `npm run lint:notes`

------
https://chatgpt.com/codex/tasks/task_e_685c5dfdfcd88325acb112f9e7867b89