### PR TITLE
Add NewsRepository with tests

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -1,3 +1,10 @@
+## 2025-08-04 PR #XX
+- **Summary**: introduced NewsRepository wrapping NewsService and updated AppStateNotifier. Added unit tests for success, failure and caching.
+- **Stage**: implementation
+- **Requirements addressed**: PF-004, FR-0104
+- **Deviations/Decisions**: repository caches for 12h and delegates to NewsService.
+- **Next step**: monitor CI.
+
 ## 2025-08-03 PR #XX
 - **Summary**: added tests for fetchJson and NetClient to reach 100% coverage.
 - **Stage**: testing

--- a/TODO.md
+++ b/TODO.md
@@ -65,7 +65,7 @@
 - [x] Integrate with AuthService.
 - [x] Integrate into PortfolioScreen.
 - [x] Implement refreshTotals and integrate with UI.
-- [ ] Extend repositories for other domains.
+- [x] Extend repositories for other domains.
 - [ ] Implement remaining repositories.
 - [ ] Enhance services to parse real API data.
 - [ ] Monitor for further API integration.

--- a/mobile-app/lib/repositories/news_repository.dart
+++ b/mobile-app/lib/repositories/news_repository.dart
@@ -1,0 +1,24 @@
+import 'package:smwa_services/services.dart';
+import '../models/news_article.dart';
+import 'package:smwa_services/src/lru_cache.dart';
+
+/// R-05 – Provides cached news articles via [NewsService].
+class NewsRepository {
+  final NewsService _svc;
+  final LruCache<String, List<NewsArticle>> _cache = LruCache(32);
+
+  NewsRepository({NewsService? service})
+      : _svc = service ??
+            NewsService(const String.fromEnvironment('VITE_NEWSDATA_KEY'));
+
+  /// Returns up to three recent articles for [symbol] using a 12h cache.
+  Future<List<NewsArticle>?> digest(String symbol) async {
+    final cached = _cache.get(symbol);
+    if (cached != null) return cached;
+    final raw = await _svc.getDigest(symbol);
+    if (raw == null) return null;
+    final list = raw.map((e) => NewsArticle.fromMap(e)).toList();
+    _cache.put(symbol, list, const Duration(hours: 12));
+    return list;
+  }
+}

--- a/mobile-app/lib/state/app_state.dart
+++ b/mobile-app/lib/state/app_state.dart
@@ -3,6 +3,7 @@ import 'package:smwa_services/services.dart';
 import '../repositories/quote_repository.dart';
 import '../models/quote.dart';
 import '../models/news_article.dart';
+import '../repositories/news_repository.dart';
 import '../repositories/watch_list_repository.dart';
 
 /// Simple state container used by the app.
@@ -26,19 +27,18 @@ class AppState {
 /// Application level state provider managing market data.
 class AppStateNotifier extends StateNotifier<AppState> {
   final QuoteRepository _quotes;
-  final NewsService _news;
+  final NewsRepository _news;
   final AuthService _auth;
   final WatchListRepository _watchRepo;
 
   /// Creates an [AppStateNotifier] with optional service overrides.
   AppStateNotifier(
       {QuoteRepository? quotes,
-      NewsService? news,
+      NewsRepository? news,
       AuthService? auth,
       WatchListRepository? watchRepo})
       : _quotes = quotes ?? QuoteRepository(),
-        _news = news ??
-            NewsService(const String.fromEnvironment('VITE_NEWSDATA_KEY')),
+        _news = news ?? NewsRepository(),
         _auth = auth ?? AuthService(),
         _watchRepo = watchRepo ?? WatchListRepository(),
         super(const AppState());
@@ -52,8 +52,7 @@ class AppStateNotifier extends StateNotifier<AppState> {
   /// Loads the headline quote and related news articles.
   Future<void> loadHeadline([String symbol = 'AAPL']) async {
     final q = await _quotes.headline(symbol);
-    final rawNews = q != null ? await _news.getDigest(symbol) : null;
-    final articles = rawNews?.map((e) => NewsArticle.fromMap(e)).toList();
+    final articles = q != null ? await _news.digest(symbol) : null;
     state = state.copyWith(headline: q, articles: articles);
   }
 

--- a/mobile-app/test/main_screen_test.dart
+++ b/mobile-app/test/main_screen_test.dart
@@ -5,6 +5,8 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:mobile_app/state/app_state.dart';
 import 'package:smwa_services/services.dart';
 import 'package:mobile_app/repositories/quote_repository.dart';
+import 'package:mobile_app/repositories/news_repository.dart';
+import 'package:mobile_app/models/news_article.dart';
 
 class _FakeMarketstackService extends MarketstackService {
   @override
@@ -20,19 +22,17 @@ class _NullMarketstackService extends MarketstackService {
   }
 }
 
-class _FakeNewsService extends NewsService {
-  _FakeNewsService() : super('x');
+class _FakeNewsRepository implements NewsRepository {
   @override
-  Future<List<Map<String, dynamic>>> getDigest(String topic) async {
-    return [];
-  }
+  Future<List<NewsArticle>?> digest(String symbol) async => [];
 }
 
 void main() {
   group('MainScreen', () {
     testWidgets('shows quote when service returns data', (tester) async {
       final repo = QuoteRepository(service: _FakeMarketstackService());
-      final notifier = AppStateNotifier(quotes: repo, news: _FakeNewsService());
+      final notifier =
+          AppStateNotifier(quotes: repo, news: _FakeNewsRepository());
       await tester.pumpWidget(
         ProviderScope(
           overrides: [appStateProvider.overrideWith((ref) => notifier)],
@@ -45,7 +45,8 @@ void main() {
 
     testWidgets('shows loading when service returns null', (tester) async {
       final repo = QuoteRepository(service: _NullMarketstackService());
-      final notifier = AppStateNotifier(quotes: repo, news: _FakeNewsService());
+      final notifier =
+          AppStateNotifier(quotes: repo, news: _FakeNewsRepository());
       await tester.pumpWidget(
         ProviderScope(
           overrides: [appStateProvider.overrideWith((ref) => notifier)],

--- a/mobile-app/test/news_repository_test.dart
+++ b/mobile-app/test/news_repository_test.dart
@@ -1,0 +1,57 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobile_app/repositories/news_repository.dart';
+import 'package:smwa_services/services.dart';
+
+class _FakeNewsService extends NewsService {
+  int calls = 0;
+  List<Map<String, dynamic>>? response;
+  _FakeNewsService({this.response}) : super('k');
+
+  @override
+  Future<List<Map<String, dynamic>>?> getDigest(String topic) async {
+    calls++;
+    return response;
+  }
+}
+
+void main() {
+  group('NewsRepository.digest', () {
+    test('returns articles on success', () async {
+      final svc = _FakeNewsService(response: [
+        {
+          'title': 't',
+          'url': 'u',
+          'source': 's',
+          'published': '2024-01-01T00:00:00Z'
+        }
+      ]);
+      final repo = NewsRepository(service: svc);
+      final list = await repo.digest('a');
+      expect(list?.first.title, 't');
+      expect(svc.calls, 1);
+    });
+
+    test('uses cache on repeat', () async {
+      final svc = _FakeNewsService(response: [
+        {
+          'title': 't',
+          'url': 'u',
+          'source': 's',
+          'published': '2024-01-01T00:00:00Z'
+        }
+      ]);
+      final repo = NewsRepository(service: svc);
+      final first = await repo.digest('a');
+      final second = await repo.digest('a');
+      expect(first, same(second));
+      expect(svc.calls, 1);
+    });
+
+    test('returns null on failure', () async {
+      final svc = _FakeNewsService(response: null);
+      final repo = NewsRepository(service: svc);
+      final list = await repo.digest('a');
+      expect(list, isNull);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- implement `NewsRepository` wrapping `NewsService`
- cover repository with positive and negative unit tests
- use `NewsRepository` in `AppStateNotifier`
- adapt main screen test
- document the change in NOTES and update TODO

## Testing
- `flutter analyze`
- `flutter test --dart-define=VITE_NEWSDATA_KEY=test`
- `npm test -C packages`
- `npm test -C web-app`
- `npm run lint:notes -C packages`
- `npm run lint:conflicts -C packages`
- `npx -y markdown-link-check README.md`
- `npx openapi lint ../spec/openapi.yaml` from packages

------
https://chatgpt.com/codex/tasks/task_e_685e957619688325ba8e547799ecada7