### PR TITLE
Add FxRepository and update currency toggle

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -1,3 +1,10 @@
+## 2025-08-04 PR #XX
+- **Summary**: added FxRepository caching FX rates via FxService, integrated into app store, and wrote tests.
+- **Stage**: implementation
+- **Requirements addressed**: FR-0107
+- **Deviations/Decisions**: repository caches rates for 24h before calling FxService to match AGENTS.md TTL.
+- **Next step**: monitor CI and expand repository coverage.
+
 ## 2025-08-03 PR #XX
 - **Summary**: added tests for fetchJson and NetClient to reach 100% coverage.
 - **Stage**: testing

--- a/TODO.md
+++ b/TODO.md
@@ -65,7 +65,7 @@
 - [x] Integrate with AuthService.
 - [x] Integrate into PortfolioScreen.
 - [x] Implement refreshTotals and integrate with UI.
-- [ ] Extend repositories for other domains.
+- [x] Extend repositories for other domains.
 - [ ] Implement remaining repositories.
 - [ ] Enhance services to parse real API data.
 - [ ] Monitor for further API integration.

--- a/web-app/src/repositories/FxRepository.ts
+++ b/web-app/src/repositories/FxRepository.ts
@@ -1,0 +1,28 @@
+import { FxService } from '@/services/FxService';
+import { LruCache } from '@/utils/LruCache';
+import { DAY_MS } from '../../../packages/core/net';
+
+/**
+ * Repository providing cached access to FX rates via FxService.
+ */
+export class FxRepository {
+  private svc: FxService;
+  private cache = new LruCache<string, number>(32);
+
+  constructor(service?: FxService) {
+    this.svc = service ?? new FxService();
+  }
+
+  /**
+   * Get conversion rate from base to quote using a 24 h cache.
+   */
+  async rate(base: string, quote: string): Promise<number | null> {
+    const key = `${base}_${quote}`;
+    const cached = this.cache.get(key);
+    if (cached !== undefined) return cached;
+    const value = await this.svc.getRate(base, quote);
+    if (value !== null) this.cache.put(key, value, DAY_MS);
+    return value;
+  }
+}
+

--- a/web-app/src/stores/appStore.ts
+++ b/web-app/src/stores/appStore.ts
@@ -3,6 +3,7 @@ import { MarketstackService, type Quote } from '@/services/MarketstackService';
 import { QuoteRepository } from '@/repositories/QuoteRepository';
 import { NewsService, type NewsArticle } from '@/services/NewsService';
 import { FxService } from '@/services/FxService';
+import { FxRepository } from '@/repositories/FxRepository';
 import { LocationService } from '@/services/LocationService';
 import {
   CountrySettingRepository,
@@ -25,7 +26,7 @@ export interface AppState {
 export interface AppDeps {
   quoteRepo?: QuoteRepository;
   newsService?: NewsService;
-  fxService?: FxService;
+  fxRepo?: FxRepository;
   trie?: SymbolTrie;
   locationService?: LocationService;
   countryRepo?: CountrySettingRepository;
@@ -69,8 +70,9 @@ export function createAppStore(deps: AppDeps = {}) {
       },
       async toggleCurrency() {
         const target = this.currency === 'USD' ? 'EUR' : 'USD';
-        const fxSvc = deps.fxService ?? new FxService();
-        const rate = await fxSvc.getRate(this.currency, target);
+        const repo =
+          deps.fxRepo ?? new FxRepository(new FxService());
+        const rate = await repo.rate(this.currency, target);
         if (rate !== null) this.currency = target;
       },
       signIn() {

--- a/web-app/tests/FxRepository.test.ts
+++ b/web-app/tests/FxRepository.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect, vi } from 'vitest';
+import { FxRepository } from '../src/repositories/FxRepository';
+
+describe('FxRepository', () => {
+  it('caches rates from service', async () => {
+    const getRate = vi.fn().mockResolvedValue(1.1);
+    const repo = new FxRepository({ getRate } as any);
+    const first = await repo.rate('USD', 'EUR');
+    const second = await repo.rate('USD', 'EUR');
+    expect(first).toBe(1.1);
+    expect(second).toBe(1.1);
+    expect(getRate).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns null on quota denial', async () => {
+    const getRate = vi.fn().mockResolvedValue(null);
+    const repo = new FxRepository({ getRate } as any);
+    const res = await repo.rate('USD', 'EUR');
+    expect(res).toBeNull();
+    expect(getRate).toHaveBeenCalled();
+  });
+});
+

--- a/web-app/tests/WatchListActions.test.ts
+++ b/web-app/tests/WatchListActions.test.ts
@@ -15,7 +15,7 @@ describe('watch list actions', () => {
       watchRepo: { list, save } as any,
       quoteRepo: new QuoteRepository({ getQuote: vi.fn() } as any),
       newsService: { getNews: vi.fn() } as any,
-      fxService: { getRate: vi.fn() } as any,
+      fxRepo: { rate: vi.fn() } as any,
       trie: { search: vi.fn().mockReturnValue([]) } as any
     })();
     await store.addToWatchList('GOOG');
@@ -29,7 +29,7 @@ describe('watch list actions', () => {
       watchRepo: { list, save } as any,
       quoteRepo: new QuoteRepository({ getQuote: vi.fn() } as any),
       newsService: { getNews: vi.fn() } as any,
-      fxService: { getRate: vi.fn() } as any,
+      fxRepo: { rate: vi.fn() } as any,
       trie: { search: vi.fn().mockReturnValue([]) } as any
     })();
     await store.addToWatchList('AAPL');
@@ -43,7 +43,7 @@ describe('watch list actions', () => {
       watchRepo: { list, save } as any,
       quoteRepo: new QuoteRepository({ getQuote: vi.fn() } as any),
       newsService: { getNews: vi.fn() } as any,
-      fxService: { getRate: vi.fn() } as any,
+      fxRepo: { rate: vi.fn() } as any,
       trie: { search: vi.fn().mockReturnValue([]) } as any
     })();
     await store.removeFromWatchList('GOOG');

--- a/web-app/tests/appStore.test.ts
+++ b/web-app/tests/appStore.test.ts
@@ -19,7 +19,7 @@ describe('appStore', () => {
     const store = createAppStore({
       quoteRepo: repo,
       newsService: { getNews } as any,
-      fxService: { getRate: vi.fn() } as any,
+      fxRepo: { rate: vi.fn() } as any,
       trie: { search: vi.fn().mockReturnValue([]) } as any
     })();
 
@@ -33,7 +33,7 @@ describe('appStore', () => {
   it('toggles currency only with valid rate', async () => {
     const getRate = vi.fn().mockResolvedValue(0.9);
     const store = createAppStore({
-      fxService: { getRate } as any,
+      fxRepo: { rate: getRate } as any,
       quoteRepo: new QuoteRepository({ getQuote: vi.fn() } as any),
       newsService: { getNews: vi.fn() } as any,
       trie: { search: vi.fn().mockReturnValue([]) } as any
@@ -46,7 +46,7 @@ describe('appStore', () => {
   it('does not toggle when rate null', async () => {
     const getRate = vi.fn().mockResolvedValue(null);
     const store = createAppStore({
-      fxService: { getRate } as any,
+      fxRepo: { rate: getRate } as any,
       quoteRepo: new QuoteRepository({ getQuote: vi.fn() } as any),
       newsService: { getNews: vi.fn() } as any,
       trie: { search: vi.fn().mockReturnValue([]) } as any
@@ -61,7 +61,7 @@ describe('appStore', () => {
       trie: { search } as any,
       quoteRepo: new QuoteRepository({ getQuote: vi.fn() } as any),
       newsService: { getNews: vi.fn() } as any,
-      fxService: { getRate: vi.fn() } as any
+      fxRepo: { rate: vi.fn() } as any
     })();
     const results = store.search('AA');
     expect(results).toEqual(['AAPL']);
@@ -73,7 +73,7 @@ describe('appStore', () => {
     const store = createAppStore({
       quoteRepo: new QuoteRepository({ getQuote: vi.fn() } as any),
       newsService: { getNews: vi.fn() } as any,
-      fxService: { getRate: vi.fn() } as any,
+      fxRepo: { rate: vi.fn() } as any,
       trie: { search: vi.fn().mockReturnValue([]) } as any
     })();
     store.signIn();
@@ -94,7 +94,7 @@ describe('appStore', () => {
     const store = createAppStore({
       quoteRepo: new QuoteRepository({ getTopMovers } as any),
       newsService: { getNews: vi.fn() } as any,
-      fxService: { getRate: vi.fn() } as any,
+      fxRepo: { rate: vi.fn() } as any,
       trie: { search: vi.fn().mockReturnValue([]) } as any,
     })();
     await store.loadTopMovers();
@@ -108,7 +108,7 @@ describe('appStore', () => {
     const store = createAppStore({
       quoteRepo: new QuoteRepository({ getTopMovers } as any),
       newsService: { getNews: vi.fn() } as any,
-      fxService: { getRate: vi.fn() } as any,
+      fxRepo: { rate: vi.fn() } as any,
       trie: { search: vi.fn().mockReturnValue([]) } as any,
     })();
     await store.loadTopMovers();
@@ -126,7 +126,7 @@ describe('appStore', () => {
     const store = createAppStore({
       quoteRepo: new QuoteRepository({ getQuote: vi.fn() } as any),
       newsService: { getNews: vi.fn() } as any,
-      fxService: { getRate: vi.fn() } as any,
+      fxRepo: { rate: vi.fn() } as any,
       trie: { search: vi.fn().mockReturnValue([]) } as any,
       countryRepo: { load } as any,
       locationService: { resolveCountry: vi.fn() } as any
@@ -147,7 +147,7 @@ describe('appStore', () => {
     const store = createAppStore({
       quoteRepo: new QuoteRepository({ getQuote: vi.fn() } as any),
       newsService: { getNews: vi.fn() } as any,
-      fxService: { getRate: vi.fn() } as any,
+      fxRepo: { rate: vi.fn() } as any,
       trie: { search: vi.fn().mockReturnValue([]) } as any,
       countryRepo: repo,
       locationService: { resolveCountry } as any


### PR DESCRIPTION
## Summary
- add `FxRepository` to cache FX rates using `FxService`
- integrate repository into Pinia store
- test FxRepository and update existing store tests
- tick TODO and record changes in NOTES

## Testing
- `npm test --prefix packages`
- `npm test --prefix web-app`
- `flutter test --dart-define=VITE_NEWSDATA_KEY=test`

------
https://chatgpt.com/codex/tasks/task_e_685e9578abcc8325a6e0b6fd1fbc7ba6