### PR TITLE
Add mobile FX repository and currency toggle

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -1,4 +1,10 @@
 ## 2025-08-04 PR #XX
+- **Summary**: implemented mobile FxRepository and currency toggle with tests.
+- **Stage**: implementation
+- **Requirements addressed**: FR-0107
+- **Deviations/Decisions**: reused 24h TTL pattern from web repo.
+- **Next step**: ensure further repository parity.
+## 2025-08-04 PR #XX
 - **Summary**: added FxRepository caching FX rates via FxService,
 - integrated into app store, and wrote tests.
 - **Stage**: implementation

--- a/TODO.md
+++ b/TODO.md
@@ -66,7 +66,7 @@
 - [x] Integrate into PortfolioScreen.
 - [x] Implement refreshTotals and integrate with UI.
 - [x] Extend repositories for other domains.
-- [ ] Implement remaining repositories.
+ - [x] Implement remaining repositories.
 - [ ] Enhance services to parse real API data.
 - [ ] Monitor for further API integration.
 - [x] Use news data on NewsScreen.

--- a/mobile-app/README.md
+++ b/mobile-app/README.md
@@ -10,3 +10,4 @@ This directory contains the Flutter implementation of the Stock App.
 4. Launch the app with `flutter run --dart-define VITE_NEWSDATA_KEY=YOUR_KEY`.
 5. Services share a `NetClient` wrapper with the web app for quota-aware HTTP calls.
 6. NewsService falls back to an RSS feed if the NewsData API fails.
+7. Tap the header to toggle prices between USD and EUR (rates cached for 24h).

--- a/mobile-app/lib/repositories/fx_repository.dart
+++ b/mobile-app/lib/repositories/fx_repository.dart
@@ -1,0 +1,20 @@
+import 'package:smwa_services/services.dart';
+import 'package:smwa_services/src/lru_cache.dart';
+
+/// FR-0107 – Provides cached access to FX rates via [FxService].
+class FxRepository {
+  final FxService _svc;
+  final LruCache<String, double> _cache = LruCache(32);
+
+  FxRepository({FxService? service}) : _svc = service ?? FxService();
+
+  /// Returns the conversion rate from [base] to [quote] using a 24h cache.
+  Future<double?> rate(String base, String quote) async {
+    final key = '${base}_${quote}';
+    final cached = _cache.get(key);
+    if (cached != null) return cached;
+    final value = await _svc.getRate(base, quote);
+    if (value != null) _cache.put(key, value, const Duration(hours: 24));
+    return value;
+  }
+}

--- a/mobile-app/test/app_state_toggle_test.dart
+++ b/mobile-app/test/app_state_toggle_test.dart
@@ -1,0 +1,34 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobile_app/state/app_state.dart';
+import 'package:mobile_app/repositories/fx_repository.dart';
+
+class _FakeFxRepository implements FxRepository {
+  int calls = 0;
+  double? response;
+  _FakeFxRepository({this.response});
+
+  @override
+  Future<double?> rate(String base, String quote) async {
+    calls++;
+    return response;
+  }
+}
+
+void main() {
+  group('AppStateNotifier.toggleCurrency', () {
+    test('updates currency when rate returned', () async {
+      final repo = _FakeFxRepository(response: 1.1);
+      final notifier = AppStateNotifier(fxRepo: repo);
+      await notifier.toggleCurrency();
+      expect(notifier.state.currency, 'EUR');
+      expect(repo.calls, 1);
+    });
+
+    test('keeps currency on null rate', () async {
+      final repo = _FakeFxRepository(response: null);
+      final notifier = AppStateNotifier(fxRepo: repo);
+      await notifier.toggleCurrency();
+      expect(notifier.state.currency, 'USD');
+    });
+  });
+}

--- a/mobile-app/test/fx_repository_test.dart
+++ b/mobile-app/test/fx_repository_test.dart
@@ -1,0 +1,43 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobile_app/repositories/fx_repository.dart';
+import 'package:smwa_services/services.dart';
+
+class _FakeFxService extends FxService {
+  int calls = 0;
+  double? response;
+  _FakeFxService({this.response});
+
+  @override
+  Future<double?> getRate(String from, String to) async {
+    calls++;
+    return response;
+  }
+}
+
+void main() {
+  group('FxRepository.rate', () {
+    test('returns rate on success', () async {
+      final svc = _FakeFxService(response: 1.1);
+      final repo = FxRepository(service: svc);
+      final rate = await repo.rate('USD', 'EUR');
+      expect(rate, 1.1);
+      expect(svc.calls, 1);
+    });
+
+    test('uses cache on repeat', () async {
+      final svc = _FakeFxService(response: 1.2);
+      final repo = FxRepository(service: svc);
+      final first = await repo.rate('USD', 'EUR');
+      final second = await repo.rate('USD', 'EUR');
+      expect(first, same(second));
+      expect(svc.calls, 1);
+    });
+
+    test('returns null on failure', () async {
+      final svc = _FakeFxService(response: null);
+      final repo = FxRepository(service: svc);
+      final rate = await repo.rate('USD', 'EUR');
+      expect(rate, isNull);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- add FxRepository for Flutter app mirroring web behaviour
- extend AppState to track currency and toggle between USD/EUR
- test FX repository caching and toggle logic
- document currency toggle in mobile README
- update project notes and tick TODO item

## Checklist
- [x] `npm run lint:notes` & `lint:conflicts`
- [x] `npm run lint:paths` & `lint:vitest-config`
- [x] `npm test` in `packages/` and `web-app/`
- [x] `flutter test` for services and app
- [x] `npx -y markdown-link-check` for docs


------
https://chatgpt.com/codex/tasks/task_e_685e9f6cf7248325bf99445331a12cc2