### PR TITLE
Parse OHLC fields

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -1,3 +1,10 @@
+## 2025-08-05 PR #XX
+- **Summary**: expanded Quote model with open/high/low/close and updated services, repository and tests to parse these fields.
+- **Stage**: implementation
+- **Requirements addressed**: FR-0101, FR-0102
+- **Deviations/Decisions**: kept price as alias of close for backward compatibility.
+- **Next step**: monitor CI, update docs if API fields change.
+
 ## 2025-08-04 PR #XX
 - **Summary**: added FxRepository caching FX rates via FxService,
 - integrated into app store, and wrote tests.

--- a/TODO.md
+++ b/TODO.md
@@ -67,7 +67,7 @@
 - [x] Implement refreshTotals and integrate with UI.
 - [x] Extend repositories for other domains.
 - [ ] Implement remaining repositories.
-- [ ] Enhance services to parse real API data.
+- [x] Enhance services to parse real API data.
 - [ ] Monitor for further API integration.
 - [x] Use news data on NewsScreen.
 - [ ] Expand store features.

--- a/mobile-app/lib/models/quote.dart
+++ b/mobile-app/lib/models/quote.dart
@@ -2,6 +2,17 @@
 class Quote {
   final String symbol;
   final double price;
+  final double open;
+  final double high;
+  final double low;
+  final double close;
 
-  const Quote({required this.symbol, required this.price});
+  const Quote({
+    required this.symbol,
+    required this.price,
+    required this.open,
+    required this.high,
+    required this.low,
+    required this.close,
+  });
 }

--- a/mobile-app/lib/repositories/quote_repository.dart
+++ b/mobile-app/lib/repositories/quote_repository.dart
@@ -20,6 +20,10 @@ class QuoteRepository {
     final quote = Quote(
       symbol: data['symbol'] as String,
       price: (data['price'] as num).toDouble(),
+      open: (data['open'] as num).toDouble(),
+      high: (data['high'] as num).toDouble(),
+      low: (data['low'] as num).toDouble(),
+      close: (data['close'] as num).toDouble(),
     );
     _headlineCache.put(symbol, quote, const Duration(hours: 24));
     return quote;
@@ -35,6 +39,10 @@ class QuoteRepository {
         .map((e) => Quote(
               symbol: e['symbol'] as String,
               price: (e['close'] as num).toDouble(),
+              open: (e['open'] as num).toDouble(),
+              high: (e['high'] as num).toDouble(),
+              low: (e['low'] as num).toDouble(),
+              close: (e['close'] as num).toDouble(),
             ))
         .toList();
     _seriesCache.put(symbol, list, const Duration(hours: 24));

--- a/mobile-app/packages/services/lib/src/marketstack_service.dart
+++ b/mobile-app/packages/services/lib/src/marketstack_service.dart
@@ -22,7 +22,14 @@ class MarketstackService {
       _cache,
       (json) {
         final raw = json['data'][0];
-        return {'symbol': raw['symbol'], 'price': raw['close']};
+        return {
+          'symbol': raw['symbol'],
+          'price': raw['close'],
+          'open': raw['open'],
+          'high': raw['high'],
+          'low': raw['low'],
+          'close': raw['close'],
+        };
       },
       ttl: const Duration(hours: 24),
     );
@@ -34,7 +41,13 @@ class MarketstackService {
       url,
       _seriesCache,
       (json) => (json['data'] as List)
-          .map((r) => {'symbol': r['symbol'], 'close': r['close']})
+          .map((r) => {
+                'symbol': r['symbol'],
+                'open': r['open'],
+                'high': r['high'],
+                'low': r['low'],
+                'close': r['close'],
+              })
           .toList(),
       ttl: const Duration(hours: 24),
     );

--- a/mobile-app/packages/services/test/marketstack_service_test.dart
+++ b/mobile-app/packages/services/test/marketstack_service_test.dart
@@ -9,7 +9,13 @@ void main() {
     final client = MockClient((req) async => http.Response(
         jsonEncode({
           'data': [
-            {'symbol': 'AAPL', 'close': 123.45}
+            {
+              'symbol': 'AAPL',
+              'open': 120.0,
+              'high': 125.0,
+              'low': 119.0,
+              'close': 123.45
+            }
           ]
         }),
         200));
@@ -17,6 +23,10 @@ void main() {
     final quote = await svc.getIndexQuote('AAPL');
     expect(quote?['symbol'], 'AAPL');
     expect(quote?['price'], 123.45);
+    expect(quote?['open'], 120.0);
+    expect(quote?['high'], 125.0);
+    expect(quote?['low'], 119.0);
+    expect(quote?['close'], 123.45);
   });
 
   test('getIndexQuote returns null on failure', () async {
@@ -33,7 +43,13 @@ void main() {
       return http.Response(
           jsonEncode({
             'data': [
-              {'symbol': 'AAPL', 'close': 1.0}
+              {
+                'symbol': 'AAPL',
+                'open': 0.8,
+                'high': 1.2,
+                'low': 0.7,
+                'close': 1.0
+              }
             ]
           }),
           200);

--- a/mobile-app/test/main_screen_test.dart
+++ b/mobile-app/test/main_screen_test.dart
@@ -11,7 +11,14 @@ import 'package:mobile_app/models/news_article.dart';
 class _FakeMarketstackService extends MarketstackService {
   @override
   Future<Map<String, dynamic>> getIndexQuote(String symbol) async {
-    return {'symbol': symbol, 'price': 1.5};
+    return {
+      'symbol': symbol,
+      'price': 1.5,
+      'open': 1.4,
+      'high': 1.6,
+      'low': 1.3,
+      'close': 1.5,
+    };
   }
 }
 

--- a/mobile-app/test/portfolio_repository_test.dart
+++ b/mobile-app/test/portfolio_repository_test.dart
@@ -13,7 +13,14 @@ class _FakeQuoteRepo implements QuoteRepository {
   @override
   Future<Quote?> headline([String symbol = 'AAPL']) async {
     calls++;
-    return Quote(symbol: symbol, price: price);
+    return Quote(
+      symbol: symbol,
+      price: price,
+      open: price - 0.1,
+      high: price + 0.1,
+      low: price - 0.2,
+      close: price,
+    );
   }
 
   @override

--- a/mobile-app/test/quote_repository_test.dart
+++ b/mobile-app/test/quote_repository_test.dart
@@ -29,12 +29,20 @@ void main() {
       final svc = _FakeMarketstackService(response: {
         'symbol': 'AAPL',
         'price': 2.5,
+        'open': 2.0,
+        'high': 3.0,
+        'low': 1.5,
+        'close': 2.5,
       });
       final repo = QuoteRepository(service: svc);
       final q = await repo.headline('AAPL');
       expect(q, isA<Quote>());
       expect(q?.symbol, 'AAPL');
       expect(q?.price, 2.5);
+      expect(q?.open, 2.0);
+      expect(q?.high, 3.0);
+      expect(q?.low, 1.5);
+      expect(q?.close, 2.5);
       expect(svc.calls, 1);
     });
 
@@ -42,6 +50,10 @@ void main() {
       final svc = _FakeMarketstackService(response: {
         'symbol': 'AAPL',
         'price': 2.5,
+        'open': 2.0,
+        'high': 3.0,
+        'low': 1.5,
+        'close': 2.5,
       });
       final repo = QuoteRepository(service: svc);
       final first = await repo.headline('AAPL');
@@ -61,19 +73,41 @@ void main() {
   group('QuoteRepository.series', () {
     test('returns list of quotes', () async {
       final svc = _FakeMarketstackService(seriesResponse: [
-        {'symbol': 'AAPL', 'close': 1.0},
-        {'symbol': 'AAPL', 'close': 2.0}
+        {
+          'symbol': 'AAPL',
+          'open': 0.8,
+          'high': 1.2,
+          'low': 0.7,
+          'close': 1.0
+        },
+        {
+          'symbol': 'AAPL',
+          'open': 1.8,
+          'high': 2.2,
+          'low': 1.7,
+          'close': 2.0
+        }
       ]);
       final repo = QuoteRepository(service: svc);
       final list = await repo.series('AAPL');
       expect(list?.length, 2);
       expect(list?.first.price, 1.0);
+      expect(list?.first.open, 0.8);
+      expect(list?.first.high, 1.2);
+      expect(list?.first.low, 0.7);
+      expect(list?.first.close, 1.0);
       expect(svc.calls, 1);
     });
 
     test('uses cache for series', () async {
       final svc = _FakeMarketstackService(seriesResponse: [
-        {'symbol': 'AAPL', 'close': 1.0},
+        {
+          'symbol': 'AAPL',
+          'open': 0.8,
+          'high': 1.2,
+          'low': 0.7,
+          'close': 1.0
+        },
       ]);
       final repo = QuoteRepository(service: svc);
       final first = await repo.series('AAPL');


### PR DESCRIPTION
## Summary
- expand Quote model with open/high/low/close
- parse those fields in MarketstackService and QuoteRepository
- test QuoteRepository with OHLC data
- update MarketstackService unit test
- mark parsing enhancement done

## Testing
- `npm run lint -C web-app`
- `npm test -C packages`
- `flutter analyze`
- `flutter test --dart-define=VITE_NEWSDATA_KEY=test`

------
https://chatgpt.com/codex/tasks/task_e_685e9f6fe8488325884063d3e9c9d5a5