### PR TITLE
Fix register return type

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -1,4 +1,11 @@
 ## 2025-08-06 PR #XX
+- **Summary**: fixed register return type using UserCredential model and added missing import.
+- **Stage**: implementation
+- **Requirements addressed**: FR-0105
+- **Deviations/Decisions**: convert service credential via toJson/fromJson to avoid type mismatch.
+- **Next step**: monitor CI for further auth flows.
+
+## 2025-08-06 PR #XX
 - **Summary**: implemented ProUpgradeService POST call via stripe-mock, added tests, new app state method and docs.
 - **Stage**: implementation
 - **Requirements addressed**: FR-0108

--- a/TODO.md
+++ b/TODO.md
@@ -121,3 +121,4 @@
 - [x] Import colours and fonts from `web-prototype/CSS/styleguide.css` into `web-app/design-tokens/tokens.json`.
 - [x] Bundle prototype fonts in the PWA (verify licenses).
 - [x] Rebuild Vue pages to match `web-prototype/*.html` using the new tokens.
+- [x] Fix AppState register return type to map service credential to domain model.

--- a/mobile-app/lib/state/app_state.dart
+++ b/mobile-app/lib/state/app_state.dart
@@ -8,6 +8,7 @@ import '../repositories/news_repository.dart';
 import '../repositories/watch_list_repository.dart';
 import '../repositories/fx_repository.dart';
 import '../repositories/credential_store.dart';
+import '../models/user_credential.dart';
 
 /// Simple state container used by the app.
 class AppState {
@@ -99,7 +100,8 @@ class AppStateNotifier extends StateNotifier<AppState> {
 
   /// Registers a new account via [AuthService].
   Future<UserCredential> register(String email, String password) async {
-    return _auth.register(email, password);
+    final svcCred = await _auth.register(email, password);
+    return UserCredential.fromJson(svcCred.toJson());
   }
 
   /// Loads and re-saves the watch list.


### PR DESCRIPTION
## Summary
- import local UserCredential model in AppState
- convert AuthService return to model in register()
- document fix in NOTES and mark TODO

## Testing
- `flutter analyze`
- `flutter test --dart-define=VITE_NEWSDATA_KEY=test --dart-define=VITE_MARKETSTACK_KEY=dummy`
- `npm run lint:notes`
- `npm run lint:conflicts`

------
https://chatgpt.com/codex/tasks/task_e_685eb2aa734c832591cf080b94df886c