### PR TITLE
Add flutter analyze step in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,9 @@ jobs:
       - name: Install Flutter dependencies
         run: flutter pub get
         working-directory: mobile-app
+      - name: Analyze Flutter code
+        run: flutter analyze --no-pub
+        working-directory: mobile-app
       - name: Run service package tests with coverage
         run: |
           flutter pub get

--- a/.github/workflows/flutter_test.yml
+++ b/.github/workflows/flutter_test.yml
@@ -22,6 +22,9 @@ jobs:
       - name: Install dependencies
         run: flutter pub get
         working-directory: mobile-app
+      - name: Analyze Flutter code
+        run: flutter analyze --no-pub
+        working-directory: mobile-app
       - name: Run service package tests
         run: |
           flutter pub get

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -129,6 +129,7 @@ caching period. Free‑tier quotas remain ≤ 100 Marketstack/FX calls · month�
   the service package has its dependencies ready.
 - Run `npm run tokens` (or run tests) before any Flutter analysis or build steps so `tokens.dart` exists.
 - Run `npm run tokens` before web tests if you invoke `npx vitest` or `npx jest` directly. Their pretest hook does not run automatically.
+- CI runs `flutter analyze --no-pub` after fetching mobile dependencies and fails on warnings.
 - Flutter tests require API keys via `--dart-define`. CI passes a dummy NewsData key:
   `flutter test --dart-define=VITE_NEWSDATA_KEY=test`.
   Include `--dart-define=VITE_MARKETSTACK_KEY=dummy` locally if Marketstack API calls run in tests.

--- a/NOTES.md
+++ b/NOTES.md
@@ -1,3 +1,10 @@
+## 2025-08-07 PR #XX
+- **Summary**: CI now runs flutter analyze without pub to fail on warnings.
+- **Stage**: maintenance
+- **Requirements addressed**: N/A
+- **Deviations/Decisions**: added analyzer step to workflows; docs updated.
+- **Next step**: monitor CI results.
+
 ## 2025-08-06 PR #XX
 - **Summary**: implemented ProUpgradeService POST call via stripe-mock, added tests, new app state method and docs.
 - **Stage**: implementation

--- a/TODO.md
+++ b/TODO.md
@@ -80,6 +80,7 @@
 - [ ] Monitor CI runs.
 - [x] Keep AGENTS.md up to date whenever CI tooling changes.
 
+- [x] Enforce flutter analyze step in CI after dependencies install.
 - [x] Add linter to verify NOTES.md entries start with a proper heading and remain newest-first.
 
 - [x] Ensure packages tests run via `npm ci` and `npm test` in CI workflow.


### PR DESCRIPTION
## Summary
- add `flutter analyze --no-pub` to main CI and flutter_test workflow
- document analyzer step in AGENTS.md
- log analyzer check in NOTES
- mark todo item for CI analyzer enforcement

## Testing
- `npm run lint:notes -C packages`
- `npm run lint:conflicts -C packages`
- `npm test -C packages`
- `npm test -C web-app`
- `flutter test --coverage --dart-define=VITE_NEWSDATA_KEY=test` *(failed: Dart compiler exited unexpectedly)*
- `flutter analyze --no-pub` *(17 issues found)*

------
https://chatgpt.com/codex/tasks/task_e_685eb2ad2a2083259da2afd7d9e758c3