### PR TITLE
docs: clarify CI secrets

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,6 +68,9 @@ LHCI_GITHUB_APP_TOKEN=YOUR_LHCI_TOKEN  # CI only
 
 (Exchangerate.host is key-less – no variable needed.)
 
+These variables must also be configured as GitHub repository secrets so CI can
+create `.env` files. Include `NETLIFY_HOOK_URL` if deploying to Netlify.
+
 ## Shared Packages
 
 - When creating a new package under `packages/`, add its `src` folder to

--- a/NOTES.md
+++ b/NOTES.md
@@ -1,3 +1,10 @@
+## 2025-08-08 PR #XX
+- **Summary**: added missing mobile .env.example and documented GitHub secrets.
+- **Stage**: documentation
+- **Requirements addressed**: N/A
+- **Deviations/Decisions**: README already listed env vars; AGENTS now states CI needs secrets.
+- **Next step**: monitor CI and keep docs synced.
+
 ## 2025-08-07 PR #XX
 - **Summary**: CI now runs flutter analyze without pub to fail on warnings.
 - **Stage**: maintenance

--- a/TODO.md
+++ b/TODO.md
@@ -2,6 +2,8 @@
 
 # TODO
 
+- [x] Add mobile .env.example and document required GitHub secrets in AGENTS.
+
 - [x] Add WatchListPage and store actions for watch list.
 
 - [x] Implement a unified network layer shared by mobile and web services.


### PR DESCRIPTION
## Summary
- document that CI loads env vars from repo secrets
- keep notes and todo in sync

## Testing
- `npm run lint:notes && npm run lint:conflicts` (pass)
- `npx -y markdown-link-check README.md` *(fails: module not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fd8b3957883259bd91f5acdad220f