### PR TITLE
Install service deps before Flutter analysis

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,9 @@ jobs:
       - name: Install Flutter dependencies
         run: flutter pub get
         working-directory: mobile-app
+      - name: Install service package deps
+        run: flutter pub get
+        working-directory: mobile-app/packages/services
       - name: Analyze Flutter code
         run: flutter analyze --no-pub
         working-directory: mobile-app

--- a/.github/workflows/flutter_test.yml
+++ b/.github/workflows/flutter_test.yml
@@ -22,6 +22,9 @@ jobs:
       - name: Install dependencies
         run: flutter pub get
         working-directory: mobile-app
+      - name: Install service package deps
+        run: flutter pub get
+        working-directory: mobile-app/packages/services
       - name: Analyze Flutter code
         run: flutter analyze --no-pub
         working-directory: mobile-app

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -127,6 +127,8 @@ caching period. Free‑tier quotas remain ≤ 100 Marketstack/FX calls · month�
   shared client packages.
 - After generating REST clients, run `flutter pub get -C mobile-app/packages/services` so
   the service package has its dependencies ready.
+- Before running Flutter analysis in CI, also run `flutter pub get -C mobile-app/packages/services`
+  so dev dependencies like `flutter_lints` are available.
 - Run `npm run tokens` (or run tests) before any Flutter analysis or build steps so `tokens.dart` exists.
 - Run `npm run tokens` before web tests if you invoke `npx vitest` or `npx jest` directly. Their pretest hook does not run automatically.
 - CI runs `flutter analyze --no-pub` after fetching mobile dependencies and fails on warnings.

--- a/NOTES.md
+++ b/NOTES.md
@@ -1,3 +1,10 @@
+## 2025-08-08 PR #XX
+- **Summary**: CI installs service package deps before Flutter analysis.
+- **Stage**: maintenance
+- **Requirements addressed**: N/A
+- **Deviations/Decisions**: added flutter pub get step in workflows; documented in AGENTS.
+- **Next step**: ensure analyze warnings disappear.
+
 ## 2025-08-07 PR #XX
 - **Summary**: CI now runs flutter analyze without pub to fail on warnings.
 - **Stage**: maintenance

--- a/TODO.md
+++ b/TODO.md
@@ -26,6 +26,7 @@
 - [x] Start **shared-contracts** repo with spec and schema folders, then bundle the public APIs (`openapi.yaml`). (Repo hosted within main project)
 - [x] Add JSON schema models with tests in shared-contracts.
 - [x] Generate design tokens via style-dictionary for CSS and Dart.
+- [x] Install service package deps before Flutter analysis in CI.
 - [x] Build Dart service package `smwa_services` using LruCache and ApiQuotaLedger.
 - [x] Implement QuoteRepository (mobile & web)
 - [x] Document tsconfig path requirement when importing packages to avoid TS6307.


### PR DESCRIPTION
## Summary
- install service package dependencies before running `flutter analyze`
- document the new CI step
- record decision in NOTES
- tick TODO entry

## Testing
- `npm --prefix packages run lint:notes`
- `npm --prefix packages run lint:conflicts`
- `flutter analyze --no-pub -d mobile-app` *(fails: include_file_not_found)*
- `npx -y markdown-link-check README.md` *(failed: Cannot find module './compile.js')*

------
https://chatgpt.com/codex/tasks/task_e_685fd890b48c832591d3800c3996a22a