### PR TITLE
Fix docs workflow dependency path

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,5 +14,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20
+      - name: Install dependencies
+        run: npm ci --prefix web-app
       - name: Check links
-        run: npx markdown-link-check README.md
+        run: npx --prefix web-app markdown-link-check README.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,7 +90,8 @@ The folder `web-prototype/` contains HTML/CSS exported from Figma. Treat it as r
 ## Docs
 
 - After editing README or other docs, run:
-  `npx markdown-link-check README.md`.
+  `npm ci --prefix web-app` then
+  `npx --prefix web-app markdown-link-check README.md`.
 
 ## API hygiene
 
@@ -146,8 +147,9 @@ caching period. Free‑tier quotas remain ≤ 100 Marketstack/FX calls · month�
 - `mobile-app/packages/services` uses Flutter plugins, so its tests must run via `flutter test` (not `dart test`).
 - The shared packages under `packages/` install via `npm ci` and run `npm test` in CI.
  - Run the documentation link check with Node 20 using the local package:
-  `npx markdown-link-check README.md`.
-- CI runs this check via `.github/workflows/docs.yml`. Run it locally whenever you edit README or other docs files.
+  `npm ci --prefix web-app` then
+  `npx --prefix web-app markdown-link-check README.md`.
+ - CI runs this check via `.github/workflows/docs.yml`. Run it locally whenever you edit README or other docs files.
 - Ensure the OpenAPI spec reports zero warnings: `npx openapi lint spec/openapi.yaml`.
 - Provide at least one positive and one negative unit test per public API, aiming for ≥75 % branch coverage.
 - Add parity tests under `web-app/tests/*Parity.test.ts` and
@@ -190,7 +192,7 @@ caching period. Free‑tier quotas remain ≤ 100 Marketstack/FX calls · month�
 
 - **Fork** then branch off `main` using the pattern `feat/<topic>`.
 - **Ensure local tests pass** before opening a PR.
-- Run `npx markdown-link-check README.md` whenever docs are updated to keep the docs CI job green.
+ - Run `npm ci --prefix web-app` and `npx --prefix web-app markdown-link-check README.md` whenever docs are updated to keep the docs CI job green.
 - Update the `<your-user>` placeholder in README badges and clone commands with your GitHub username after forking.
 - **Each PR requires at least one reviewer.**
 

--- a/NOTES.md
+++ b/NOTES.md
@@ -1,3 +1,10 @@
+## 2025-08-09 PR #XX
+- **Summary**: docs workflow installs deps in web-app and runs link check via prefix.
+- **Stage**: maintenance
+- **Requirements addressed**: N/A
+- **Deviations/Decisions**: check uses `npm ci --prefix web-app` and `npx --prefix web-app markdown-link-check README.md`.
+- **Next step**: monitor docs job in CI.
+
 ## 2025-08-08 PR #XX
 - **Summary**: disabled package publishing for mobile to silence Flutter warning.
 - **Stage**: maintenance

--- a/README.md
+++ b/README.md
@@ -151,7 +151,8 @@ imports of `web-app/src` use the correct relative paths.
 Run the documentation checks with Node 20 (no `-y` needed once the package is
 installed locally):
 ```bash
-npx markdown-link-check README.md
+npm ci --prefix web-app
+npx --prefix web-app markdown-link-check README.md
 ```
 
 flutter test and npm test – keep CI green


### PR DESCRIPTION
## Summary
- install web-app dependencies during docs workflow
- check markdown links using web-app's package
- document updated command for link check

## Testing
- `npm run lint:notes` *(passed)*
- `npx --prefix web-app markdown-link-check README.md` *(failed: Cannot find module './compile.js')*

------
https://chatgpt.com/codex/tasks/task_e_685fdf7c457c8325b8620be3ac5148ff