### PR TITLE
Update service exports and clean up Dart code

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -1,4 +1,11 @@
 ## 2025-08-08 PR #XX
+- **Summary**: aligned repositories with service exports and cleaned code.
+- **Stage**: maintenance
+- **Requirements addressed**: N/A
+- **Deviations/Decisions**: added flutter_lints to services; removed _cred; used services.dart imports.
+- **Next step**: verify CI stays green.
+
+## 2025-08-08 PR #XX
 - **Summary**: disabled package publishing for mobile to silence Flutter warning.
 - **Stage**: maintenance
 - **Requirements addressed**: N/A

--- a/TODO.md
+++ b/TODO.md
@@ -1,4 +1,5 @@
 - [x] Split font weights from font family tokens for easier CSS usage.
+- [x] Cleaned Flutter services and repositories; removed unused fields and fixed imports.
 
 # TODO
 

--- a/mobile-app/lib/repositories/country_setting_repository.dart
+++ b/mobile-app/lib/repositories/country_setting_repository.dart
@@ -1,6 +1,6 @@
 import 'dart:convert';
 import 'package:shared_preferences/shared_preferences.dart';
-import 'package:smwa_services/src/country_setting_repository.dart' as repo;
+import 'package:smwa_services/services.dart' as repo;
 import '../models/country_setting.dart';
 
 class CountrySettingRepository implements repo.CountrySettingRepository {

--- a/mobile-app/lib/repositories/fx_repository.dart
+++ b/mobile-app/lib/repositories/fx_repository.dart
@@ -1,5 +1,4 @@
 import 'package:smwa_services/services.dart';
-import 'package:smwa_services/src/lru_cache.dart';
 
 /// FR-0107 – Provides cached access to FX rates via [FxService].
 class FxRepository {
@@ -10,7 +9,7 @@ class FxRepository {
 
   /// Returns the conversion rate from [base] to [quote] using a 24h cache.
   Future<double?> rate(String base, String quote) async {
-    final key = '${base}_${quote}';
+    final key = '${base}_$quote';
     final cached = _cache.get(key);
     if (cached != null) return cached;
     final value = await _svc.getRate(base, quote);

--- a/mobile-app/lib/repositories/news_repository.dart
+++ b/mobile-app/lib/repositories/news_repository.dart
@@ -1,6 +1,5 @@
 import 'package:smwa_services/services.dart';
 import '../models/news_article.dart';
-import 'package:smwa_services/src/lru_cache.dart';
 
 /// R-05 – Provides cached news articles via [NewsService].
 class NewsRepository {

--- a/mobile-app/lib/repositories/portfolio_repository.dart
+++ b/mobile-app/lib/repositories/portfolio_repository.dart
@@ -3,7 +3,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 import '../models/portfolio_holding.dart';
 import '../models/quote.dart';
 import 'quote_repository.dart';
-import 'package:smwa_services/src/lru_cache.dart';
+import 'package:smwa_services/services.dart';
 
 /// R-02 – CRUD access to portfolio holdings using SharedPreferences.
 class PortfolioRepository {

--- a/mobile-app/lib/repositories/quote_repository.dart
+++ b/mobile-app/lib/repositories/quote_repository.dart
@@ -1,6 +1,5 @@
 import 'package:smwa_services/services.dart';
 import '../models/quote.dart';
-import 'package:smwa_services/src/lru_cache.dart';
 
 /// R-01 – Provides cached access to quotes via [MarketstackService].
 class QuoteRepository {

--- a/mobile-app/lib/state/app_state.dart
+++ b/mobile-app/lib/state/app_state.dart
@@ -42,11 +42,10 @@ class AppStateNotifier extends StateNotifier<AppState> {
   final svc.AuthService _auth;
   final WatchListRepository _watchRepo;
   final FxRepository _fx;
-  final CredentialStore _cred;
   final svc.ProUpgradeService _proSvc;
 
   AppStateNotifier._(this._quotes, this._news, this._auth, this._watchRepo,
-      this._fx, this._cred, this._proSvc)
+      this._fx, this._proSvc)
       : super(const AppState());
 
   /// Creates an [AppStateNotifier] with optional service overrides.
@@ -56,17 +55,15 @@ class AppStateNotifier extends StateNotifier<AppState> {
     svc.AuthService? auth,
     WatchListRepository? watchRepo,
     FxRepository? fxRepo,
-    CredentialStore? credStore,
     svc.ProUpgradeService? proSvc,
   }) {
-    final store = credStore ?? CredentialStore();
+    final store = CredentialStore();
     return AppStateNotifier._(
       quotes ?? QuoteRepository(),
       news ?? NewsRepository(),
       auth ?? svc.AuthService(),
       watchRepo ?? WatchListRepository(),
       fxRepo ?? FxRepository(),
-      store,
       proSvc ?? svc.ProUpgradeService(store.updateProFlag),
     );
   }
@@ -117,7 +114,8 @@ class AppStateNotifier extends StateNotifier<AppState> {
 }
 
 /// Riverpod provider exposing the application state.
-final authServiceProvider = Provider<svc.AuthService>((ref) => svc.AuthService());
+final authServiceProvider =
+    Provider<svc.AuthService>((ref) => svc.AuthService());
 
 final appStateProvider = StateNotifierProvider<AppStateNotifier, AppState>(
   (ref) => AppStateNotifier(auth: ref.read(authServiceProvider)),

--- a/mobile-app/packages/services/lib/services.dart
+++ b/mobile-app/packages/services/lib/services.dart
@@ -9,3 +9,4 @@ export 'src/pro_upgrade_service.dart';
 export 'src/fetch_json.dart';
 export 'src/credential_store.dart';
 export 'src/user_credential.dart';
+export 'src/country_setting_repository.dart';

--- a/mobile-app/packages/services/lib/src/fx_service.dart
+++ b/mobile-app/packages/services/lib/src/fx_service.dart
@@ -14,7 +14,6 @@ class FxService {
   }
 
   Future<double?> getRate(String from, String to) async {
-    final key = '$from-$to';
     final url = 'https://api.exchangerate.host/latest?base=$from&symbols=$to';
     return _net.get<double>(
       url,

--- a/mobile-app/packages/services/lib/src/news_service.dart
+++ b/mobile-app/packages/services/lib/src/news_service.dart
@@ -58,10 +58,10 @@ class NewsService {
       final doc = XmlDocument.parse(resp.body);
       final items = doc.findAllElements('item').take(3).map((n) {
         return {
-          'title': n.getElement('title')?.text ?? '',
-          'url': n.getElement('link')?.text ?? '',
+          'title': n.getElement('title')?.innerText ?? '',
+          'url': n.getElement('link')?.innerText ?? '',
           'source': 'rss',
-          'published': n.getElement('pubDate')?.text ?? '',
+          'published': n.getElement('pubDate')?.innerText ?? '',
         };
       }).toList();
       _rssCache.put(_rssUrl, items, const Duration(hours: 12));

--- a/mobile-app/packages/services/pubspec.lock
+++ b/mobile-app/packages/services/pubspec.lock
@@ -158,6 +158,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_lints:
+    dependency: "direct dev"
+    description:
+      name: flutter_lints
+      sha256: "9e8c3858111da373efc5aa341de011d9bd23e2c5c5e0c62bccf32438e192d7b1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.2"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -328,6 +336,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.1"
+  lints:
+    dependency: transitive
+    description:
+      name: lints
+      sha256: cbf8d4b858bb0134ef3ef87841abdf8d63bfc255c266b7bf6b39daa1085c4290
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.0"
   logging:
     dependency: transitive
     description:

--- a/mobile-app/packages/services/pubspec.yaml
+++ b/mobile-app/packages/services/pubspec.yaml
@@ -17,3 +17,4 @@ dev_dependencies:
   test: ^1.24.0
   flutter_test:
     sdk: flutter
+  flutter_lints: ^3.0.1


### PR DESCRIPTION
## Summary
- expose `CountrySettingRepository` from services package
- depend on `flutter_lints` for service package
- use exported services across mobile repositories
- simplify FX repo key interpolation
- tidy unused variables and HTML parsing
- drop unused credential store field
- document progress in NOTES and TODO

## Testing
- `npm run lint:notes`
- `npm run lint:conflicts`
- `dart format` on updated files
- `flutter analyze --no-pub` in mobile-app
- `flutter test --dart-define=VITE_NEWSDATA_KEY=test` (packages/services)
- `flutter test --dart-define=VITE_NEWSDATA_KEY=test` (mobile-app)


------
https://chatgpt.com/codex/tasks/task_e_685fdf7ac08c8325bf2669da30e7ecb4