### PR TITLE
Fix analyzer warnings in services tests

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -1,3 +1,10 @@
+## 2025-08-10 PR #XX
+- **Summary**: fixed lints in auth service and tests; removed unused imports; changed rss variables to const.
+- **Stage**: maintenance
+- **Requirements addressed**: N/A
+- **Deviations/Decisions**: root flutter analyze missing flutter_lints, ran analysis in mobile-app.
+- **Next step**: monitor CI for clean run.
+
 ## 2025-08-09 PR #XX
 - **Summary**: docs workflow installs deps in web-app and runs link check via prefix.
 - **Stage**: maintenance

--- a/mobile-app/packages/services/lib/src/auth_service.dart
+++ b/mobile-app/packages/services/lib/src/auth_service.dart
@@ -1,4 +1,4 @@
-/// S-05 – AuthService
+// S-05 – AuthService
 import 'package:bcrypt/bcrypt.dart';
 
 import 'credential_store.dart';

--- a/mobile-app/packages/services/test/location_service_parity_test.dart
+++ b/mobile-app/packages/services/test/location_service_parity_test.dart
@@ -1,6 +1,5 @@
 import 'package:smwa_services/services.dart';
 import 'package:smwa_services/src/location_service.dart' as loc;
-import 'package:smwa_services/src/country_setting_repository.dart';
 import 'package:smwa_services/src/country_setting.dart';
 import 'package:geolocator/geolocator.dart';
 import 'package:flutter_test/flutter_test.dart';

--- a/mobile-app/packages/services/test/location_service_test.dart
+++ b/mobile-app/packages/services/test/location_service_test.dart
@@ -1,6 +1,5 @@
 import 'package:smwa_services/services.dart';
 import 'package:smwa_services/src/location_service.dart' as loc;
-import 'package:smwa_services/src/country_setting_repository.dart';
 import 'package:smwa_services/src/country_setting.dart';
 import 'package:geolocator/geolocator.dart';
 import 'package:geocoding/geocoding.dart';

--- a/mobile-app/packages/services/test/news_service_parity_test.dart
+++ b/mobile-app/packages/services/test/news_service_parity_test.dart
@@ -73,7 +73,7 @@ void main() {
 
   test('falls back to rss when api fails', () async {
     var calls = 0;
-    final rss =
+    const rss =
         '<?xml version="1.0"?><rss><channel><item><title>r</title><link>u</link><pubDate>d</pubDate></item></channel></rss>';
     final client = MockClient((req) async {
       calls++;

--- a/mobile-app/packages/services/test/news_service_test.dart
+++ b/mobile-app/packages/services/test/news_service_test.dart
@@ -48,7 +48,7 @@ void main() {
 
   test('falls back to rss on failure', () async {
     var calls = 0;
-    final rss =
+    const rss =
         '''<rss><channel><item><title>r</title><link>l</link><pubDate>p</pubDate></item></channel></rss>''';
     final client = MockClient((req) async {
       calls++;


### PR DESCRIPTION
## Summary
- convert AuthService header to a plain comment
- drop unused CountrySettingRepository imports
- mark RSS XML strings as const
- update NOTES

## Testing
- `flutter analyze --no-pub` (inside mobile-app)
- `flutter test --dart-define=VITE_NEWSDATA_KEY=test --dart-define=VITE_MARKETSTACK_KEY=dummy` in `mobile-app/packages/services`
- `flutter test --dart-define=VITE_NEWSDATA_KEY=test --dart-define=VITE_MARKETSTACK_KEY=dummy` in `mobile-app`


------
https://chatgpt.com/codex/tasks/task_e_685fec0561fc83258cba655540ed2da3