### PR TITLE
Update AGENTS with css-select note

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,6 +94,8 @@ The folder `web-prototype/` contains HTML/CSS exported from Figma. Treat it as r
   npm ci -C web-app
   npx markdown-link-check README.md
   ```
+- The docs workflow pins `css-select@4` to keep markdown-link-check stable. Keep
+  this override in `web-app/package.json`.
 ## API hygiene
 
 (API requests are implemented in service classes under `web-app/src/services/`.)
@@ -114,6 +116,8 @@ caching period. Free‑tier quotas remain ≤ 100 Marketstack/FX calls · month�
 - Secrets must remain in `.env`; never commit real API keys.
 - Use 2‑space indentation, single quotes and end files with a newline.
 - Document each public API/function with a doc comment.
+- Avoid file-leading `///` comments unless followed by a `library` directive.
+  Use standard `//` comments for file headers.
 - When introducing new JS packages in `web-app`, also install the matching
   `@types/...` package (or provide a custom `.d.ts`) to prevent TS7016
   compilation errors.

--- a/NOTES.md
+++ b/NOTES.md
@@ -1,3 +1,10 @@
+## 2025-08-10 PR #XX
+- **Summary**: documented css-select override and triple-slash rule.
+- **Stage**: documentation
+- **Requirements addressed**: N/A
+- **Deviations/Decisions**: AGENTS now warns against file-leading `///` unless with `library` and notes css-select pin.
+- **Next step**: confirm docs workflow stays green.
+
 ## 2025-08-09 PR #XX
 - **Summary**: docs workflow installs deps in web-app and runs link check via prefix.
 - **Stage**: maintenance

--- a/TODO.md
+++ b/TODO.md
@@ -129,3 +129,4 @@
 - [x] Rebuild Vue pages to match `web-prototype/*.html` using the new tokens.
 - [x] Fix AppState register return type to map service credential to domain model.
 - [x] Disable package publishing via 'publish_to: none' in mobile pubspec to silence Flutter analyzer warning.
+- [x] Document css-select override for docs workflow.


### PR DESCRIPTION
## Summary
- clarify comment style for file headers
- mention css-select@4 override in docs section
- log the docs change in NOTES
- track docs change in TODO

## Testing
- `npm run lint:notes --silent`
- `npm run lint:conflicts --silent`
- `npm ci -C web-app`
- `npx --prefix web-app markdown-link-check README.md` *(fails: Cannot find module './compile.js')*

------
https://chatgpt.com/codex/tasks/task_e_685fec08df9483259c1ac31c15f8c85f