### PR TITLE
Upgrade markdown-link-check to 3.13.7

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,8 +94,8 @@ The folder `web-prototype/` contains HTML/CSS exported from Figma. Treat it as r
   npm ci -C web-app
   npx markdown-link-check README.md
   ```
-- The docs workflow pins `css-select@4` to keep markdown-link-check stable. Keep
-  this override in `web-app/package.json`.
+ - The docs workflow pins `markdown-link-check` to version 3.13.7 and overrides
+   `css-select` to 5.1.0. Keep these settings in `web-app/package.json`.
 
 ## API hygiene
 

--- a/NOTES.md
+++ b/NOTES.md
@@ -1,3 +1,12 @@
+## 2025-08-11 PR #XX
+
+- **Summary**: bumped markdown-link-check to 3.13.7 after docs job failed with a
+  TypeError.
+- **Stage**: maintenance
+- **Requirements addressed**: N/A
+- **Deviations/Decisions**: upgraded package and kept css-select override.
+- **Next step**: verify docs workflow passes.
+
 ## 2025-08-10 PR #XX
 - **Summary**: documented css-select override and triple-slash rule.
 - **Stage**: documentation

--- a/TODO.md
+++ b/TODO.md
@@ -130,3 +130,5 @@
 - [x] Fix AppState register return type to map service credential to domain model.
 - [x] Disable package publishing via 'publish_to: none' in mobile pubspec to silence Flutter analyzer warning.
 - [x] Document css-select override for docs workflow.
+- [x] Upgrade markdown-link-check to v3.13.7 after docs job failed with a
+  TypeError.

--- a/web-app/package-lock.json
+++ b/web-app/package-lock.json
@@ -35,7 +35,7 @@
         "jest": "^29.7.0",
         "jest-environment-jsdom": "^30.0.0",
         "jsdom": "^26.1.0",
-        "markdown-link-check": "3.11.1",
+        "markdown-link-check": "3.13.7",
         "ts-jest": "^29.1.1",
         "typescript": "~5.8.3",
         "vite": "^6.3.5",
@@ -2182,6 +2182,58 @@
       "integrity": "sha512-XuySG1E38YScSJoMlqovLru4KTUNSjgVTIjyh7qMX6aNN5HY5Ct5LhRJdxO79JtTzKfzV/bnWpz+zquYrISsvw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@oozcitak/dom": {
+      "version": "1.15.10",
+      "resolved": "https://registry.npmjs.org/@oozcitak/dom/-/dom-1.15.10.tgz",
+      "integrity": "sha512-0JT29/LaxVgRcGKvHmSrUTEvZ8BXvZhGl2LASRUgHqDTC1M5g1pLmVv56IYNyt3bG2CUjDkc67wnyZC14pbQrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oozcitak/infra": "1.0.8",
+        "@oozcitak/url": "1.0.4",
+        "@oozcitak/util": "8.3.8"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/@oozcitak/infra": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@oozcitak/infra/-/infra-1.0.8.tgz",
+      "integrity": "sha512-JRAUc9VR6IGHOL7OGF+yrvs0LO8SlqGnPAMqyzOuFZPSZSXI7Xf2O9+awQPSMXgIWGtgUf/dA6Hs6X6ySEaWTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oozcitak/util": "8.3.8"
+      },
+      "engines": {
+        "node": ">=6.0"
+      }
+    },
+    "node_modules/@oozcitak/url": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@oozcitak/url/-/url-1.0.4.tgz",
+      "integrity": "sha512-kDcD8y+y3FCSOvnBI6HJgl00viO/nGbQoCINmQ0h98OhnGITrWR3bOGfwYCthgcrV8AnTJz8MzslTQbC3SOAmw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oozcitak/infra": "1.0.8",
+        "@oozcitak/util": "8.3.8"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/@oozcitak/util": {
+      "version": "8.3.8",
+      "resolved": "https://registry.npmjs.org/@oozcitak/util/-/util-8.3.8.tgz",
+      "integrity": "sha512-T8TbSnGsxo6TDBJx/Sgv/BlVJL3tshxZP7Aq5R1mSnM5OcHY2dQaxLMu2+E8u3gN0MLOzdjurqN4ZRVuzQycOQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0"
+      }
     },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
@@ -6798,7 +6850,8 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/lodash.memoize": {
       "version": "4.1.2",
@@ -6886,20 +6939,21 @@
       }
     },
     "node_modules/markdown-link-check": {
-      "version": "3.11.1",
-      "resolved": "https://registry.npmjs.org/markdown-link-check/-/markdown-link-check-3.11.1.tgz",
-      "integrity": "sha512-1O5CYb1qbrQGwG9kx3GKZ1t128ZMojKZwDCrGP7mC/xvXSF8KfMjcSUhdtdhvNJeDyNUO23YaAu7hSD72h9w5Q==",
+      "version": "3.13.7",
+      "resolved": "https://registry.npmjs.org/markdown-link-check/-/markdown-link-check-3.13.7.tgz",
+      "integrity": "sha512-Btn3HU8s2Uyh1ZfzmyZEkp64zp2+RAjwfQt1u4swq2Xa6w37OW0T2inQZrkSNVxDSa2jSN2YYhw/JkAp5jF1PQ==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "async": "^3.2.4",
-        "chalk": "^5.2.0",
-        "commander": "^10.0.0",
-        "link-check": "^5.2.0",
-        "lodash": "^4.17.21",
-        "markdown-link-extractor": "^3.1.0",
-        "needle": "^3.2.0",
-        "progress": "^2.0.3"
+        "async": "^3.2.6",
+        "chalk": "^5.3.0",
+        "commander": "^13.1.0",
+        "link-check": "^5.4.0",
+        "markdown-link-extractor": "^4.0.2",
+        "needle": "^3.3.1",
+        "progress": "^2.0.3",
+        "proxy-agent": "^6.4.0",
+        "xmlbuilder2": "^3.1.1"
       },
       "bin": {
         "markdown-link-check": "markdown-link-check"
@@ -6918,28 +6972,38 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/markdown-link-check/node_modules/commander": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz",
+      "integrity": "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/markdown-link-extractor": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/markdown-link-extractor/-/markdown-link-extractor-3.1.0.tgz",
-      "integrity": "sha512-r0NEbP1dsM+IqB62Ru9TXLP/HDaTdBNIeylYXumuBi6Xv4ufjE1/g3TnslYL8VNqNcGAGbMptQFHrrdfoZ/Sug==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/markdown-link-extractor/-/markdown-link-extractor-4.0.2.tgz",
+      "integrity": "sha512-5cUOu4Vwx1wenJgxaudsJ8xwLUMN7747yDJX3V/L7+gi3e4MsCm7w5nbrDQQy8nEfnl4r5NV3pDXMAjhGXYXAw==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
         "html-link-extractor": "^1.0.5",
-        "marked": "^4.1.0"
+        "marked": "^12.0.1"
       }
     },
     "node_modules/marked": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
-      "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
+      "version": "12.0.2",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-12.0.2.tgz",
+      "integrity": "sha512-qXUm7e/YKFoqFPYPa3Ukg9xlI5cyAtGmyEIzMfW//m6kXwCy2Ps9DYf5ioijFKQ8qyuscrHoY04iJGctu2Kg0Q==",
       "dev": true,
       "license": "MIT",
       "bin": {
         "marked": "bin/marked.js"
       },
       "engines": {
-        "node": ">= 12"
+        "node": ">= 18"
       }
     },
     "node_modules/merge-stream": {
@@ -9310,6 +9374,53 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/xmlbuilder2": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder2/-/xmlbuilder2-3.1.1.tgz",
+      "integrity": "sha512-WCSfbfZnQDdLQLiMdGUQpMxxckeQ4oZNMNhLVkcekTu7xhD4tuUDyAPoY8CwXvBYE6LwBHd6QW2WZXlOWr1vCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oozcitak/dom": "1.15.10",
+        "@oozcitak/infra": "1.0.8",
+        "@oozcitak/util": "8.3.8",
+        "js-yaml": "3.14.1"
+      },
+      "engines": {
+        "node": ">=12.0"
+      }
+    },
+    "node_modules/xmlbuilder2/node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/xmlbuilder2/node_modules/js-yaml": {
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/xmlbuilder2/node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "dev": true,
+      "license": "BSD-3-Clause"
     },
     "node_modules/xmlchars": {
       "version": "2.2.0",

--- a/web-app/package.json
+++ b/web-app/package.json
@@ -43,7 +43,7 @@
     "vite": "^6.3.5",
     "vitest": "^3.2.1",
     "vue-tsc": "^2.2.8",
-    "markdown-link-check": "3.11.1",
+    "markdown-link-check": "3.13.7",
     "cheerio": "1.0.0-rc.12",
     "css-select": "5.1.0"
   },


### PR DESCRIPTION
## Summary
- upgrade `markdown-link-check` to v3.13.7
- regenerate lockfile
- document pinned version and css-select override
- log the dependency update
- mark TODO item complete

## Testing
- `npm run lint:notes --prefix packages`
- `npm run lint:conflicts --prefix packages`
- `npm test --prefix packages`
- `npm test --prefix web-app`
- `flutter analyze --no-pub`
- `flutter pub get -C mobile-app`
- `flutter pub get -C mobile-app/packages/services`
- `flutter test --coverage --dart-define=VITE_NEWSDATA_KEY=test`

------
https://chatgpt.com/codex/tasks/task_e_685ff6a55a308325b065b095544da64d