### PR TITLE
Add flutter_lints check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,9 @@ jobs:
       - name: Install service package deps
         run: flutter pub get
         working-directory: mobile-app/packages/services
+      - name: Check Flutter lints dependency
+        run: npm run lint:flutter-lints
+        working-directory: packages
       - name: Analyze Flutter code
         run: flutter analyze --no-pub
         working-directory: mobile-app

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -147,6 +147,7 @@ caching period. Free‑tier quotas remain ≤ 100 Marketstack/FX calls · month�
 - Any Flutter package whose `analysis_options.yaml` includes
   `package:flutter_lints/flutter.yaml` must list `flutter_lints` under
   `dev_dependencies`.
+- Verify this via `npm run lint:flutter-lints`; CI runs this check before Flutter analysis.
 - Run `npm run tokens` (or run tests) before any Flutter analysis or build steps so `tokens.dart` exists.
 - Run `npm run tokens` before web tests if you invoke `npx vitest` or `npx jest` directly. Their pretest hook does not run automatically.
 - CI runs `flutter analyze --no-pub` after fetching mobile dependencies and fails on warnings.

--- a/NOTES.md
+++ b/NOTES.md
@@ -1,3 +1,11 @@
+## 2025-08-12 PR #XX
+
+- **Summary**: added script to check flutter_lints usage and integrated in CI.
+- **Stage**: maintenance
+- **Requirements addressed**: N/A
+- **Deviations/Decisions**: ensures packages declare flutter_lints when included.
+- **Next step**: monitor CI for new check.
+
 ## 2025-08-11 PR #XX
 
 - **Summary**: bumped markdown-link-check to 3.13.7 after docs job failed with a
@@ -1551,3 +1559,5 @@ npm test
 - **Requirements addressed**: N/A
 - **Deviations/Decisions**: None
 - **Next step**: Populate TODO.md and implement core services.
+
+

--- a/TODO.md
+++ b/TODO.md
@@ -83,7 +83,7 @@
 - [ ] Wire Flutter store.
 - [x] Monitor CI runs.
 - [x] Keep AGENTS.md up to date whenever CI tooling changes.
-- [ ] Audit Flutter packages for flutter_lints dev dependency.
+- [x] Audit Flutter packages for flutter_lints dev dependency.
 
 - [x] Enforce flutter analyze step in CI after dependencies install.
 - [x] Add linter to verify NOTES.md entries start with a proper heading and remain newest-first.

--- a/packages/package.json
+++ b/packages/package.json
@@ -13,6 +13,7 @@
     "lint:paths": "node ../scripts/check-package-paths.mjs",
     "lint:notes": "node ../scripts/check-notes-order.mjs",
     "lint:conflicts": "node ../scripts/check-conflicts.mjs",
+    "lint:flutter-lints": "node ../scripts/check-flutter-lints.mjs",
     "test": "vitest run --config vitest.config.ts --coverage --coverage.include=core/net.ts --coverage.exclude=**/generated-ts/** --coverage.exclude=**/generated-dart/** --coverage.exclude=**/core/src/**"
   },
   "devDependencies": {

--- a/scripts/check-flutter-lints.mjs
+++ b/scripts/check-flutter-lints.mjs
@@ -1,0 +1,88 @@
+import fs from 'fs/promises';
+import path from 'path';
+
+const __dirname = path.dirname(new URL(import.meta.url).pathname);
+const root = path.resolve(__dirname, '..');
+
+const ignoreDirs = new Set(['node_modules', '.git', '.dart_tool', 'generated-dart', 'generated-ts', 'build']);
+
+async function walk(dir) {
+  const entries = await fs.readdir(dir, { withFileTypes: true });
+  const files = [];
+  for (const e of entries) {
+    const full = path.join(dir, e.name);
+    if (e.isDirectory()) {
+      if (!ignoreDirs.has(e.name)) {
+        files.push(...await walk(full));
+      }
+    } else if (e.isFile() && e.name === 'pubspec.yaml') {
+      files.push(full);
+    }
+  }
+  return files;
+}
+
+async function includesFlutterLints(file, seen = new Set()) {
+  if (seen.has(file)) return false;
+  seen.add(file);
+  let text;
+  try {
+    text = await fs.readFile(file, 'utf8');
+  } catch {
+    return false;
+  }
+  if (text.includes('package:flutter_lints/flutter.yaml')) {
+    return true;
+  }
+  const m = text.match(/^\s*include:\s*(.+)$/m);
+  if (m) {
+    let include = m[1].trim().replace(/^['"]|['"]$/g, '');
+    if (include.startsWith('package:flutter_lints')) {
+      return true;
+    }
+    if (!include.startsWith('package:')) {
+      const next = path.resolve(path.dirname(file), include);
+      return includesFlutterLints(next, seen);
+    }
+  }
+  return false;
+}
+
+async function hasFlutterLintsDev(pubspec) {
+  const text = await fs.readFile(pubspec, 'utf8');
+  const lines = text.split(/\r?\n/);
+  let inDev = false;
+  for (const line of lines) {
+    if (/^dev_dependencies:\s*$/.test(line)) {
+      inDev = true;
+      continue;
+    }
+    if (inDev) {
+      if (/^\S/.test(line)) break;
+      const m = line.match(/^\s*(\S+):/);
+      if (m && m[1] === 'flutter_lints') return true;
+    }
+  }
+  return false;
+}
+
+(async () => {
+  const pubspecs = await walk(root);
+  const problems = [];
+  for (const spec of pubspecs) {
+    const dir = path.dirname(spec);
+    const analysis = path.join(dir, 'analysis_options.yaml');
+    if (await includesFlutterLints(analysis)) {
+      if (!await hasFlutterLintsDev(spec)) {
+        problems.push(`${spec} missing flutter_lints dev dependency`);
+      }
+    }
+  }
+  if (problems.length) {
+    console.error('flutter_lints dependency check failed:');
+    for (const p of problems) console.error('  ' + p);
+    process.exit(1);
+  } else {
+    console.log('Flutter lints dependencies are correct.');
+  }
+})();


### PR DESCRIPTION
## Summary
- add script `check-flutter-lints.mjs` to ensure packages using flutter_lints declare it
- expose `lint:flutter-lints` in packages package.json
- run the script in CI before flutter analysis
- document requirement in AGENTS
- note update in project notes and tick TODO item

## Testing
- `npm run lint:notes --silent --prefix packages`
- `npm run lint:conflicts --silent --prefix packages`
- `npm run lint:paths --silent --prefix packages`
- `npm run lint:vitest-config --silent --prefix packages`
- `node scripts/check-flutter-lints.mjs`
- `npm run lint:flutter-lints --silent --prefix packages`
- `npm test --silent --prefix packages`
- `npm test --silent --prefix web-app`
- `(cd mobile-app && flutter analyze --no-pub)`
- `(cd mobile-app/packages/services && flutter test --coverage --dart-define=VITE_NEWSDATA_KEY=test)`
- `(cd mobile-app && flutter test --coverage --dart-define=VITE_NEWSDATA_KEY=test)`

------
https://chatgpt.com/codex/tasks/task_e_68600682937883259c90a8751f75ef4d