### PR TITLE
Add portfolio actions to web store

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -1,3 +1,11 @@
+## 2025-08-12 PR #XX
+
+- **Summary**: added portfolio actions to web store and unit tests.
+- **Stage**: implementation
+- **Requirements addressed**: FR-0106
+- **Deviations/Decisions**: mirrored Flutter PortfolioNotifier via new appStore actions.
+- **Next step**: integrate holdings view into PortfolioPage.
+
 ## 2025-08-11 PR #XX
 
 - **Summary**: bumped markdown-link-check to 3.13.7 after docs job failed with a

--- a/TODO.md
+++ b/TODO.md
@@ -74,7 +74,8 @@
 - [x] Implement remaining repositories.
 - [ ] Monitor for further API integration.
 - [x] Use news data on NewsScreen.
-- [ ] Expand store features.
+- [x] Expand store features.
+- [ ] Integrate portfolio holdings view with PortfolioPage.
 - [x] Implement ranking for SymbolTrie suggestions.
 - [x] Integrate helper in mobile services.
 - [x] Flesh out real API calls.

--- a/web-app/tests/PortfolioActions.test.ts
+++ b/web-app/tests/PortfolioActions.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { createPinia, setActivePinia } from 'pinia';
+import { createAppStore } from '../src/stores/appStore';
+import { QuoteRepository } from '../src/repositories/QuoteRepository';
+
+beforeEach(() => {
+  setActivePinia(createPinia());
+});
+
+describe('portfolio actions', () => {
+  it('loads holdings and totals', async () => {
+    const sample = { id: '1', symbol: 'AAPL', quantity: 1, buyPrice: 1, added: '2024-01-01T00:00:00Z' };
+    const list = vi.fn().mockResolvedValue([sample]);
+    const refreshTotals = vi.fn().mockResolvedValue(2);
+    const store = createAppStore({
+      portfolioRepo: { list, refreshTotals } as any,
+      watchRepo: { list: vi.fn().mockResolvedValue([]), save: vi.fn() } as any,
+      quoteRepo: new QuoteRepository({ getQuote: vi.fn() } as any),
+      newsService: { getNews: vi.fn() } as any,
+      fxRepo: { rate: vi.fn() } as any,
+      trie: { search: vi.fn().mockReturnValue([]) } as any
+    })();
+    await store.loadPortfolio();
+    expect(store.holdings).toEqual([sample]);
+    expect(store.portfolioTotal).toBe(2);
+    expect(list).toHaveBeenCalled();
+    expect(refreshTotals).toHaveBeenCalled();
+  });
+
+  it('adds holding and refreshes state', async () => {
+    const sample = { id: '1', symbol: 'AAPL', quantity: 1, buyPrice: 1, added: '2024-01-01T00:00:00Z' };
+    const add = vi.fn();
+    const list = vi.fn().mockResolvedValue([sample]);
+    const refreshTotals = vi.fn().mockResolvedValue(2);
+    const store = createAppStore({
+      portfolioRepo: { add, list, refreshTotals } as any,
+      watchRepo: { list: vi.fn().mockResolvedValue([]), save: vi.fn() } as any,
+      quoteRepo: new QuoteRepository({ getQuote: vi.fn() } as any),
+      newsService: { getNews: vi.fn() } as any,
+      fxRepo: { rate: vi.fn() } as any,
+      trie: { search: vi.fn().mockReturnValue([]) } as any
+    })();
+    await store.addHolding(sample);
+    expect(add).toHaveBeenCalledWith(sample);
+    expect(store.holdings).toEqual([sample]);
+    expect(store.portfolioTotal).toBe(2);
+  });
+
+  it('removes holding and refreshes state', async () => {
+    const list = vi.fn().mockResolvedValue([]);
+    const refreshTotals = vi.fn().mockResolvedValue(0);
+    const remove = vi.fn();
+    const store = createAppStore({
+      portfolioRepo: { remove, list, refreshTotals } as any,
+      watchRepo: { list: vi.fn().mockResolvedValue([]), save: vi.fn() } as any,
+      quoteRepo: new QuoteRepository({ getQuote: vi.fn() } as any),
+      newsService: { getNews: vi.fn() } as any,
+      fxRepo: { rate: vi.fn() } as any,
+      trie: { search: vi.fn().mockReturnValue([]) } as any
+    })();
+    await store.removeHolding('1');
+    expect(remove).toHaveBeenCalledWith('1');
+    expect(store.holdings).toEqual([]);
+    expect(store.portfolioTotal).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- extend app store with PortfolioRepository actions
- cover new actions with PortfolioActions tests
- log the update in NOTES
- tick TODO item for store features

## Checklist
- [x] `npm run lint:notes --prefix packages`
- [x] `npm run lint:conflicts --prefix packages`
- [x] `npm test --prefix web-app`
- [x] `npm test --prefix packages`


------
https://chatgpt.com/codex/tasks/task_e_68600684a168832589cd18fb09bb7c63