### PR TITLE
Integrate portfolio holdings view

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -1,3 +1,11 @@
+## 2025-08-13 PR #XX
+
+- **Summary**: integrated PortfolioPage with Pinia actions, rendering holdings list and totals. Updated tests.
+- **Stage**: implementation
+- **Requirements addressed**: FR-0106
+- **Deviations/Decisions**: simple table layout; store hooks handle add/remove.
+- **Next step**: monitor CI for coverage.
+
 ## 2025-08-12 PR #XX
 - **Summary**: added portfolio actions to web store and unit tests.
 - **Stage**: implementation

--- a/TODO.md
+++ b/TODO.md
@@ -75,7 +75,7 @@
 - [ ] Monitor for further API integration.
 - [x] Use news data on NewsScreen.
 - [x] Expand store features.
-- [ ] Integrate portfolio holdings view with PortfolioPage.
+- [x] Integrate portfolio holdings view with PortfolioPage.
 - [x] Implement ranking for SymbolTrie suggestions.
 - [x] Integrate helper in mobile services.
 - [x] Flesh out real API calls.

--- a/web-app/src/pages/PortfolioPage.vue
+++ b/web-app/src/pages/PortfolioPage.vue
@@ -1,6 +1,24 @@
 <template>
   <div class="page">
     <h1>Portfolio Page</h1>
+    <table v-if="holdings.length">
+      <thead>
+        <tr>
+          <th>Symbol</th>
+          <th>Qty</th>
+          <th>Buy Price</th>
+          <th></th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr v-for="h in holdings" :key="h.id">
+          <td>{{ h.symbol }}</td>
+          <td>{{ h.quantity }}</td>
+          <td>{{ h.buyPrice }}</td>
+          <td><button @click="removeHolding(h.id)">Remove</button></td>
+        </tr>
+      </tbody>
+    </table>
     <p>Total Value: {{ total }}</p>
   </div>
 </template>
@@ -8,16 +26,25 @@
 <script setup lang="ts">
 import { useLoadTimeLogger } from '@/utils/useLoadTimeLogger';
 import { useAppStore } from '@/stores/appStore';
-import { PortfolioRepository } from '@/repositories/PortfolioRepository';
-import { ref, onMounted } from 'vue';
+import type { PortfolioHolding } from '@/repositories/PortfolioRepository';
+import { computed, onMounted } from 'vue';
 const store = useAppStore();
-const repo = new PortfolioRepository();
-const total = ref(0);
+const holdings = computed(() => store.holdings);
+const total = computed(() => store.portfolioTotal);
 
 onMounted(async () => {
   store.syncWatchList();
-  total.value = await repo.refreshTotals();
+  await store.loadPortfolio();
 });
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars, no-unused-vars
+async function addHolding(h: PortfolioHolding) {
+  await store.addHolding(h);
+}
+
+async function removeHolding(id: string) {
+  await store.removeHolding(id);
+}
 
 useLoadTimeLogger('PortfolioPage');
 </script>

--- a/web-app/tests/Pages.test.ts
+++ b/web-app/tests/Pages.test.ts
@@ -39,6 +39,11 @@ beforeEach(() => {
     search: vi.fn().mockReturnValue([]),
     upgradePro: vi.fn(),
     syncWatchList: vi.fn(),
+    holdings: [],
+    portfolioTotal: 0,
+    loadPortfolio: vi.fn(),
+    addHolding: vi.fn(),
+    removeHolding: vi.fn(),
     topGainers: [],
     topLosers: []
   };

--- a/web-app/tests/PortfolioPageTotals.test.ts
+++ b/web-app/tests/PortfolioPageTotals.test.ts
@@ -2,38 +2,54 @@ import { mount } from '@vue/test-utils';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { createPinia, setActivePinia } from 'pinia';
 import PortfolioPage from '../src/pages/PortfolioPage.vue';
-import { set } from 'idb-keyval';
-import 'fake-indexeddb/auto';
+import { nextTick, reactive } from 'vue';
 
 let storeMock: any;
 vi.mock('../src/stores/appStore', () => ({
   useAppStore: () => storeMock
 }));
 
-const getQuote = vi.fn();
-vi.mock('../src/services/MarketstackService', () => ({
-  MarketstackService: vi.fn().mockImplementation(() => ({
-    getQuote
-  }))
-}));
-
-beforeEach(async () => {
+beforeEach(() => {
   setActivePinia(createPinia());
-  storeMock = { syncWatchList: vi.fn() };
-  getQuote.mockReset();
-  await set('holdings', [
-    { id: '1', symbol: 'AAPL', quantity: 2, buyPrice: 1, added: '2024-01-01T00:00:00Z' },
-    { id: '2', symbol: 'AAPL', quantity: 3, buyPrice: 1, added: '2024-01-01T00:00:00Z' }
-  ]);
+  storeMock = reactive({
+    holdings: [],
+    portfolioTotal: 0,
+    syncWatchList: vi.fn(),
+    loadPortfolio: vi.fn().mockImplementation(function () {
+      this.holdings = [
+        { id: '1', symbol: 'AAPL', quantity: 2, buyPrice: 1, added: '2024-01-01T00:00:00Z' }
+      ];
+      this.portfolioTotal = 2;
+    }),
+    addHolding: vi.fn().mockImplementation(function (h) {
+      this.holdings.push(h);
+      this.portfolioTotal += h.quantity;
+    }),
+    removeHolding: vi.fn().mockImplementation(function (id) {
+      this.holdings = this.holdings.filter((h: any) => h.id !== id);
+      this.portfolioTotal = this.holdings.reduce((t: number, h: any) => t + h.quantity, 0);
+    })
+  });
 });
 
 describe('PortfolioPage totals', () => {
-  it('shows total using cached quote', async () => {
-    getQuote.mockResolvedValue({ symbol: 'AAPL', price: 2, open: 2, high: 2, low: 2, close: 2 });
+  it('renders list and updates totals', async () => {
     const wrapper = mount(PortfolioPage);
     await new Promise(r => setTimeout(r, 0));
-    await new Promise(r => setTimeout(r, 0));
-    expect(wrapper.text()).toContain('Total Value: 10');
-    expect(getQuote).toHaveBeenCalledTimes(1);
+    expect(storeMock.loadPortfolio).toHaveBeenCalled();
+    expect(wrapper.text()).toContain('AAPL');
+    expect(wrapper.text()).toContain('Total Value: 2');
+
+    await wrapper.vm.addHolding({ id: '2', symbol: 'GOOG', quantity: 1, buyPrice: 1, added: '' });
+    await nextTick();
+    expect(storeMock.addHolding).toHaveBeenCalled();
+    expect(wrapper.text()).toContain('GOOG');
+    expect(wrapper.text()).toContain('Total Value: 3');
+
+    await wrapper.vm.removeHolding('1');
+    await nextTick();
+    expect(storeMock.removeHolding).toHaveBeenCalledWith('1');
+    expect(wrapper.text()).not.toContain('AAPL');
+    expect(wrapper.text()).toContain('Total Value: 1');
   });
 });


### PR DESCRIPTION
## Summary
- load portfolio data from app store in `PortfolioPage`
- add Pinia add/remove hooks
- render holdings in a table and display total
- update tests for new behaviour
- note change in NOTES and tick TODO

## Checklist
- [x] `npm run lint:notes` and `npm run lint:conflicts`
- [x] `npm test` for packages and web-app
- [x] `flutter test` for mobile and services packages
- [ ] `npx markdown-link-check README.md` *(failed: missing packages)*


------
https://chatgpt.com/codex/tasks/task_e_68600d3ead60832593fb0e7f7c652946